### PR TITLE
Return exit code 1 if build fails

### DIFF
--- a/build.js
+++ b/build.js
@@ -35,8 +35,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-function build(debug)
-{
+function getBuildSystem(debug) {
     var cmakeJS = require('cmake-js');
     var os = require('os');
 
@@ -65,7 +64,7 @@ function build(debug)
         buildSystem.options.arch = defaultWinArch;
     }
 
-    buildSystem.rebuild();
+    return buildSystem;
 }
 
 var times = 0;
@@ -79,8 +78,9 @@ function begin(args) {
         if (args[i] === '--debug') debug = true;
     }
 
+    var buildSystem;
     try {
-        build(debug);
+        buildSystem = getBuildSystem(debug);
     } catch (e) {
         if (e.code == 'MODULE_NOT_FOUND') {
             if (times++ == 5) {
@@ -92,6 +92,10 @@ function begin(args) {
             throw e;
         }
     }
+
+    buildSystem.rebuild().catch(e => {
+        process.exit(1);
+    });
 }
 
 begin(process.argv);


### PR DESCRIPTION
The build script should exit with code 1 if there is something wrong with the build. If not, the CI server will not detect that the build has failed, and will just continue as if everything is fine.

The `buildSystem.rebuild()` function returns a promise. We have to catch errors from that promise, and return `process.exit(1)`.

Tested on Linux and Windows.