### PR TITLE
Add test results that can be parsed by Bamboo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 build
+jest.json

--- a/api/dfu.js
+++ b/api/dfu.js
@@ -295,7 +295,9 @@ class Dfu extends EventEmitter {
         return Promise.all([
             this._loadZipAsync(zipFilePath),
             this._getManifestAsync(zipFilePath)
-        ]).then(([zip, manifest]) => {
+        ]).then(result => {
+            const zip = result[0];
+            const manifest = result[1];
             return this._getFirmwareTypes(manifest).map(type => {
                 const firmwareUpdate = manifest[type];
                 const datFileName = firmwareUpdate['dat_file'];

--- a/api/util/__tests__/intArrayConv-test.js
+++ b/api/util/__tests__/intArrayConv-test.js
@@ -36,7 +36,9 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-const { intToArray, arrayToInt } = require('../intArrayConv');
+
+const intToArray = require('../intArrayConv').intToArray;
+const arrayToInt = require('../intArrayConv').arrayToInt;
 
 describe('Integer/array conversions', () => {
 

--- a/config/jest-unit.config
+++ b/config/jest-unit.config
@@ -1,3 +1,4 @@
 {
-  "testPathDirs": ["api"]
+  "testPathDirs": ["api"],
+  "testResultsProcessor": "node_modules/jest-bamboo-formatter"
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "change-case": "2.3.0",
         "cmake-js": "1.1.0",
         "crc": "^3.4.0",
+        "jest-bamboo-formatter": "0.0.3",
         "jszip": "^3.1.2",
         "nan": "2.3.3",
         "underscore": "^1.8.3"


### PR DESCRIPTION
The Bamboo build jobs now include a task that runs `npm test`. In order to see test results properly in Bamboo, Jest must be configured to output a json file that Bamboo can parse. Added jest-bamboo-formatter as a devDependency, and set it up in the jest configuration. This will output test results to jest.json when running tests.

In Bamboo, the following configuration had to be added in order to parse tests:

![image](https://cloud.githubusercontent.com/assets/461755/22287772/5b70ded6-e2f4-11e6-867f-5ee545afed23.png)

When adding the `npm test` task, the build started failing on Linux. This is because Linux is still running Node v4, and we had used some syntax that is not supported in v4. Made some minor adjustments to make it work on v4.