### PR TITLE
rm unneeded lambda func

### DIFF
--- a/api/device.js
+++ b/api/device.js
@@ -200,7 +200,7 @@ class Device {
 
     _processFlagsFromAdvertisingData(advertisingData) {
         if (advertisingData && advertisingData.BLE_GAP_AD_TYPE_FLAGS) {
-            this.flags = advertisingData.BLE_GAP_AD_TYPE_FLAGS.map(flag => _camelCaseFlag(flag));
+            this.flags = advertisingData.BLE_GAP_AD_TYPE_FLAGS.map(_camelCaseFlag);
         }
     }
 


### PR DESCRIPTION
`Array.prototype.map` can take in a function reference, there's no need to wrap it up in a lambda arrow function there. This should result in a tiny tiny tiny perf improvement.