### PR TITLE
Correct advertising packet max size

### DIFF
--- a/api/util/adType.js
+++ b/api/util/adType.js
@@ -39,7 +39,7 @@
 
 'use strict';
 
-const AD_PACKET_MAX_SIZE = 20;
+const AD_PACKET_MAX_SIZE = 31;
 
 // Remove hyphens and reverse byte ordering to little endian
 let cleanUpUuid = function (uuid) {


### PR DESCRIPTION
According to Bluetooth Core spec. the correct max size of an advertising packet is 31 octets.