### PR TITLE
Add missing call to stored callback

### DIFF
--- a/api/adapter.js
+++ b/api/adapter.js
@@ -2281,9 +2281,12 @@ class Adapter extends EventEmitter {
                 this.emit('error', newError);
                 if (callback) { callback(newError); }
             } else {
+                const errorObject = _makeError('Connection canceled.');
+                const connectingCallback = this._gapOperationsMap.connecting.callback;
+                if (connectingCallback) connectingCallback(errorObject);
                 delete this._gapOperationsMap.connecting;
                 this._changeState({ connecting: false });
-                if (callback) { callback(undefined); }
+                if (callback) { callback(); }
             }
         });
     }


### PR DESCRIPTION
When a connection procedure is initiated, a callback is stored to be resolved when a connection has
been established, failed, timed out or canceled. For the cancelConnect operation, the stored
callback was not being called.
Resolves #46