### PR TITLE
Default export api flattened

### DIFF
--- a/examples/heart_rate_collector.js
+++ b/examples/heart_rate_collector.js
@@ -49,7 +49,7 @@
 
 const _ = require('underscore');
 
-const api = require('../index').api;
+const api = require('../index');
 
 
 const adapterFactory = api.AdapterFactory.getInstance();

--- a/examples/heart_rate_monitor.js
+++ b/examples/heart_rate_monitor.js
@@ -49,7 +49,7 @@
 
 const _ = require('underscore');
 
-const api = require('../index').api;
+const api = require('../index');
 
 
 const adapterFactory = api.AdapterFactory.getInstance();

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ const ServiceFactory = require('./api/serviceFactory');
 const Dfu = require('./api/dfu');
 const firmware = require('./api/firmware');
 
-module.exports.api = {
+module.exports = {
     Adapter,
     AdapterFactory,
     AdapterState,

--- a/local_typings/index.d.ts
+++ b/local_typings/index.d.ts
@@ -130,15 +130,4 @@ export class ServiceFactory {
   createDescriptor(characteristic: Characteristic, uuid: string, value: string, options: string);
 }
 
-export const api: {
-  AdapterFactory: typeof AdapterFactory;
-  Adapter: typeof Adapter;
-  AdapterState: typeof AdapterState;
-  Characteristic: typeof Characteristic;
-  Device: typeof Device;
-  Service: typeof Service;
-  Descriptor: typeof Descriptor;
-  ServiceFactory: typeof ServiceFactory;
-};
-
 export const driver: any;

--- a/test/dfu.js
+++ b/test/dfu.js
@@ -53,7 +53,7 @@
  */
 
 const assert = require('assert');
-const api = require('../index').api;
+const api = require('../index');
 const adapterFactory = require('./setup').adapterFactory;
 
 function setupAdapter(adapter, callback) {

--- a/test/setup.js
+++ b/test/setup.js
@@ -39,7 +39,7 @@
 
 'use strict';
 
-const api = require('../index').api;
+const api = require('../index');
 
 const adapterFactory = api.AdapterFactory.getInstance();
 const ServiceFactory = new api.ServiceFactory();


### PR DESCRIPTION
As we discussed about changing the way apps should import apis from nrfconnect we also a agreed ti would be more logical to export bleDriver's api a level higher.

https://github.com/NordicSemiconductor/pc-yggdrasil/pull/22#discussion_r114533881
