### PR TITLE
Remove unreliable tests

### DIFF
--- a/api/dfu/__tests__/dfuSpeedometer-test.js
+++ b/api/dfu/__tests__/dfuSpeedometer-test.js
@@ -102,25 +102,6 @@ describe('when initialized with total bytes 102400 and completed bytes 0', () =>
     it('should be 0% completed', () => {
         expect(speedometer.calculatePercentCompleted()).toBe(0);
     });
-
-    describe('when setting completed bytes to 10000', () => {
-        const completedBytes = 10000;
-        beforeEach(() => {
-            speedometer.updateState(completedBytes);
-        });
-
-        it('should have bytes per second larger than zero', () => {
-            expect(speedometer.calculateBytesPerSecond()).toBeGreaterThan(0);
-        });
-
-        it('should have average bytes per second larger than zero', () => {
-            expect(speedometer.calculateAverageBytesPerSecond()).toBeGreaterThan(0);
-        });
-
-        it('should be 9% completed', () => {
-            expect(speedometer.calculatePercentCompleted()).toBe(9);
-        });
-    });
 });
 
 describe('when initialized with total bytes 102400, completed bytes 1000, and start time', () => {


### PR DESCRIPTION
The dfuSpeedometer.js keeps track of DFU transfer speed and progress. If startTime is not given in the constructor, and currentTime is not given in updateState(), it will create Date objects internally and use these to calculate bytes per second.

If the constructor and updateState() are invoked right after each other, which may happen in unit tests, the time difference in ms between startTime and currentTime may be 0. Then it is not possible to calculate bytes per second, and calculateBytesPerSecond() will return 0. We have seen failing tests on the CI server because of this.

Unit tests that rely on system time are not reliable, so removing these tests. It is better to allow the unit tests to inject/mock the time. We are doing this in other tests in this file, and I believe they provide enough coverage in this case.