### PR TITLE
Add bleEnabled to AdapterState

### DIFF
--- a/api/adapter.js
+++ b/api/adapter.js
@@ -399,8 +399,9 @@ class Adapter extends EventEmitter {
             this.emit('opened', this);
 
             if (options.enableBLE) {
+                this._changeState({ bleEnabled: true });
                 this.getState(getStateError => {
-                    if (this._checkAndPropagateError(getStateError, 'Error retrieving adapter state.', callback)) { return; }
+                    this._checkAndPropagateError(getStateError, 'Error retrieving adapter state.', callback);
                 });
             }
 
@@ -417,7 +418,10 @@ class Adapter extends EventEmitter {
      * @returns {void}
      */
     close(callback) {
-        this._changeState({ available: false });
+        this._changeState({
+            available: false,
+            bleEnabled: false,
+        });
         this._adapter.close(error => {
             /**
              * Adapter closed event.
@@ -511,7 +515,7 @@ class Adapter extends EventEmitter {
             options,
             (err, parameters, app_ram_base) => {
                 if (this._checkAndPropagateError(err, 'Enabling BLE failed.', callback)) { return; }
-
+                this._changeState({ bleEnabled: true });
                 if (callback) {
                     callback(err, parameters, app_ram_base);
                 }
@@ -525,6 +529,7 @@ class Adapter extends EventEmitter {
                 this._changeState(
                     {
                         available: false,
+                        bleEnabled: false,
                         connecting: false,
                         scanning: false,
                         advertising: false,
@@ -1997,6 +2002,7 @@ class Adapter extends EventEmitter {
 
                     changedStates.address = address;
                     changedStates.available = true;
+                    changedStates.bleEnabled = true;
 
                     this._changeState(changedStates);
                     if (callback) { callback(undefined, this._state); }

--- a/api/adapterState.js
+++ b/api/adapterState.js
@@ -58,6 +58,12 @@ class AdapterState {
         this.flowControl = null;
 
         this.available = false;
+
+        /**
+         * Whether the BLE stack has been enabled.
+         * @type {boolean}
+         */
+        this.bleEnabled = false;
         this.scanning = false;
         this.advertising = false;
         this.connecting = false;

--- a/api/adapterState.js
+++ b/api/adapterState.js
@@ -52,11 +52,33 @@ class AdapterState {
         this._instanceId = `${instanceId}.${port}`;
         this._port = port;
         this._serialNumber = serialNumber;
+        this._address = null;
+        this._addressType = null;
 
+        /**
+         * The baud rate that the adapter's serial port is configured with.
+         * @type {number}
+         */
         this.baudRate = null;
+
+        /**
+         * The parity that the adapter's serial port is configured with.
+         * Can be either 'none' or 'even'.
+         * @type {string}
+         */
         this.parity = null;
+
+        /**
+         * Whether flow control is configured for this adapter's serial port.
+         * Can be either 'none' or 'hw'.
+         * @type {string}
+         */
         this.flowControl = null;
 
+        /**
+         * Whether the adapter is available and successfully opened.
+         * @type {boolean}
+         */
         this.available = false;
 
         /**
@@ -64,13 +86,35 @@ class AdapterState {
          * @type {boolean}
          */
         this.bleEnabled = false;
+
+        /**
+         * Whether the adapter is currently scanning for devices.
+         * @type {boolean}
+         */
         this.scanning = false;
+
+        /**
+         * Whether the adapter is currently advertising.
+         * @type {boolean}
+         */
         this.advertising = false;
+
+        /**
+         * Whether the adapter is currently connecting to a device.
+         * @type {boolean}
+         */
         this.connecting = false;
 
-        this._address = null;
-        this._addressType = null;
+        /**
+         * The device name that is related to this adapter.
+         * @type {string}
+         */
         this.name = null;
+
+        /**
+         * The SoftDevice firmware version used by this adapter.
+         * @type {string}
+         */
         this.firmwareVersion = null;
     }
 


### PR DESCRIPTION
Adding `bleEnabled` to AdapterState as requested in #78.

There is already an `available` status which was not documented. As far as I can see, this indicates that the adapter has been opened. Adding documentation for `available` and the other instance members in AdapterState.