### PR TITLE
Do not close adapter if it is not open

### DIFF
--- a/api/adapter.js
+++ b/api/adapter.js
@@ -418,6 +418,10 @@ class Adapter extends EventEmitter {
      * @returns {void}
      */
     close(callback) {
+        if (!this._state.available) {
+            if (callback) callback();
+            return;
+        }
         this._changeState({
             available: false,
             bleEnabled: false,


### PR DESCRIPTION
According to #79, a segfault occurs when calling close before open. Now checking if the adapter is actually open before attempting to close.

I was a bit unsure whether to return an error (e.g. "tried to close, but adapter is not open") in the callback here. With the existing implementation it seems that once the adapter has been opened and closed once, it will not return an error when calling close on an already closed adapter. Some users may rely on this behavior, so I decided not to return an error in the callback. Let me know if you disagree.