### PR TITLE
Fix MTU error in DFU example

### DIFF
--- a/test/dfu.js
+++ b/test/dfu.js
@@ -58,13 +58,16 @@ function setupAdapter(adapter, callback) {
         baudRate: 1000000,
         parity: 'none',
         flowControl: 'none',
-        enableBLE: true,
+        enableBLE: false,
         eventInterval: 0,
     };
 
     adapter.open(options, error => {
         assert(!error);
-        callback();
+        adapter.enableBLE(null, err => {
+            assert(!err);
+            callback();
+        });
     });
 }
 


### PR DESCRIPTION
The DFU example errors out with "Failed to request att mtu" if `enableBLE: true` when opening adapter. Have to call `adapter.enableBLE()` after opening the adapter instead.