### PR TITLE
Emit debug message instead of error for unsupported devkits

### DIFF
--- a/api/adapterFactory.js
+++ b/api/adapterFactory.js
@@ -42,6 +42,7 @@ const _bleDriverV2 = require('bindings')('pc-ble-driver-js-sd_api_v2');
 const _bleDriverV3 = require('bindings')('pc-ble-driver-js-sd_api_v3');
 
 const Adapter = require('./adapter');
+const logLevel = require('./util/logLevel');
 const EventEmitter = require('events');
 
 const _bleDrivers = { v2: _bleDriverV2, v3: _bleDriverV3 };
@@ -51,7 +52,17 @@ const _singleton = Symbol('Ensure that only one instance of AdapterFactory ever 
 const UPDATE_INTERVAL_MS = 2000;
 
 /**
+ * Log message event.
+ *
+ * @event AdapterFactory#logMessage
+ * @param {string} severity Severity of the log event.
+ * @param {string} message Human-readable log message.
+ */
+
+/**
  * Class that provides Adapters through the use of the pc-ble-driver AddOn and the internal `Adapter` class.
+ *
+ * @fires AdapterFactory#logMessage
  */
 class AdapterFactory extends EventEmitter {
     /**
@@ -199,7 +210,7 @@ class AdapterFactory extends EventEmitter {
                         this.emit('added', newAdapter);
                     }
                 } catch (error) {
-                    this.emit('error', error);
+                    this.emit('logMessage', logLevel.DEBUG, `Unable to create adapter: ${error.message}`);
                 }
             }
 

--- a/api/adapterFactory.js
+++ b/api/adapterFactory.js
@@ -52,6 +52,41 @@ const _singleton = Symbol('Ensure that only one instance of AdapterFactory ever 
 const UPDATE_INTERVAL_MS = 2000;
 
 /**
+ * Adapter added event. Fired when a new devkit is found.
+ *
+ * @event AdapterFactory#added
+ * @param {object} adapter The adapter instance that was added.
+ */
+
+/**
+ * Adapter removed event. Fired when a devkit is removed.
+ *
+ * @event AdapterFactory#removed
+ * @param {object} adapter The adapter instance that was removed.
+ */
+
+/**
+ * Adapter opened event.
+ *
+ * @event AdapterFactory#adapterOpened
+ * @param {object} adapter The adapter instance that was opened.
+ */
+
+/**
+ * Adapter closed event.
+ *
+ * @event AdapterFactory#adapterClosed
+ * @param {object} adapter The adapter instance that was closed.
+ */
+
+/**
+ * Error event.
+ *
+ * @event AdapterFactory#error
+ * @param {Error} error Error object with a human-readable message.
+ */
+
+/**
  * Log message event.
  *
  * @event AdapterFactory#logMessage
@@ -62,6 +97,11 @@ const UPDATE_INTERVAL_MS = 2000;
 /**
  * Class that provides Adapters through the use of the pc-ble-driver AddOn and the internal `Adapter` class.
  *
+ * @fires AdapterFactory#added
+ * @fires AdapterFactory#removed
+ * @fires AdapterFactory#adapterOpened
+ * @fires AdapterFactory#adapterClosed
+ * @fires AdapterFactory#error
  * @fires AdapterFactory#logMessage
  */
 class AdapterFactory extends EventEmitter {


### PR DESCRIPTION
The AdapterFactory monitors changes to connected devkits/dongles and emits events when a kit has been added/removed etc. If an unsupported device is found, the AdapterFactory would emit an error every 2 seconds. Instead of emitting an error in this case, we now emit a debug log message to make it less intrusive.