### PR TITLE
Fix/retransmission interval

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pc-ble-driver"]
 	path = pc-ble-driver
 	url = https://github.com/NordicSemiconductor/pc-ble-driver.git
-	branch = v2.1.0
+	branch = v2.1.1

--- a/api/adapter.js
+++ b/api/adapter.js
@@ -335,8 +335,8 @@ class Adapter extends EventEmitter {
      * <li>{number} [eventInterval=0]: Interval to use for sending BLE driver events to JavaScript.
      *                                 If `0`, events will be sent as soon as they are received from the BLE driver.
      * <li>{string} [logLevel='info']: The verbosity of logging the developer wants with this adapter.
-     * <li>{number} [retransmissionInterval=100]: The time interval to wait between retransmitted packets.
-     * <li>{number} [responseTimeout=750]: Response timeout of the data link layer.
+     * <li>{number} [retransmissionInterval=250]: The time interval to wait between retransmitted packets.
+     * <li>{number} [responseTimeout=1500]: Response timeout of the data link layer.
      * <li>{boolean} [enableBLE=true]: Whether the BLE stack should be initialized and enabled.
      * </ul>
      * @param {function(Error)} [callback] Callback signature: err => {}.
@@ -363,8 +363,8 @@ class Adapter extends EventEmitter {
                 flowControl: 'none',
                 eventInterval: 0,
                 logLevel: 'info',
-                retransmissionInterval: 100,
-                responseTimeout: 750,
+                retransmissionInterval: 250,
+                responseTimeout: 1500,
                 enableBLE: true,
             };
         } else {
@@ -373,8 +373,8 @@ class Adapter extends EventEmitter {
             if (!options.flowControl) options.flowControl = 'none';
             if (!options.eventInterval) options.eventInterval = 0;
             if (!options.logLevel) options.logLevel = 'info';
-            if (!options.retransmissionInterval) options.retransmissionInterval = 100;
-            if (!options.responseTimeout) options.responseTimeout = 750;
+            if (!options.retransmissionInterval) options.retransmissionInterval = 250;
+            if (!options.responseTimeout) options.responseTimeout = 1500;
             if (options.enableBLE === undefined) options.enableBLE = true;
         }
 

--- a/api/firmwareUpdater.js
+++ b/api/firmwareUpdater.js
@@ -52,14 +52,14 @@ const VERSION_INFO_LENGTH = 24;
 
 const firmwareMap = {
     0: { // nrf51
-        win32: path.join(sdV2Dir, 'connectivity_1.2.0_1m_with_s130_2.0.1.hex'),
-        linux: path.join(sdV2Dir, 'connectivity_1.2.0_1m_with_s130_2.0.1.hex'),
-        darwin: path.join(sdV2Dir, 'connectivity_1.2.0_115k2_with_s130_2.0.1.hex'),
+        win32: path.join(sdV2Dir, 'connectivity_1.2.1_1m_with_s130_2.0.1.hex'),
+        linux: path.join(sdV2Dir, 'connectivity_1.2.1_1m_with_s130_2.0.1.hex'),
+        darwin: path.join(sdV2Dir, 'connectivity_1.2.1_115k2_with_s130_2.0.1.hex'),
     },
     1: { // nrf52
-        win32: path.join(sdV3Dir, 'connectivity_1.2.0_1m_with_s132_3.0.hex'),
-        linux: path.join(sdV3Dir, 'connectivity_1.2.0_1m_with_s132_3.0.hex'),
-        darwin: path.join(sdV3Dir, 'connectivity_1.2.0_115k2_with_s132_3.0.hex'),
+        win32: path.join(sdV3Dir, 'connectivity_1.2.1_1m_with_s132_3.0.hex'),
+        linux: path.join(sdV3Dir, 'connectivity_1.2.1_1m_with_s132_3.0.hex'),
+        darwin: path.join(sdV3Dir, 'connectivity_1.2.1_115k2_with_s132_3.0.hex'),
     },
 };
 


### PR DESCRIPTION
Increase retransmission interval to give the peer more time to repond, and to reduce the number of retransmissions.
Update reference to pc-ble-driver to tag v2.1.1, which updates retransmission interval values for connectivity firmware.