### PR TITLE
Include error details if requesting ATT MTU fails

### DIFF
--- a/api/adapter.js
+++ b/api/adapter.js
@@ -2585,24 +2585,24 @@ class Adapter extends EventEmitter {
         const device = this.getDevice(deviceInstanceId);
 
         if (!device) {
-            const errorObject = _makeError('Failed to request att mtu', 'Failed to find device with id ' + deviceInstanceId);
+            const errorObject = _makeError(`Failed to request att mtu. Failed to find device with id ${deviceInstanceId}`);
             if (callback) callback(errorObject);
             return;
         }
 
         if (this._gattOperationsMap[device.instanceId]) {
-            this.emit('error', _makeError('Failed to get services, a GATT operation already in progress'));
+            this.emit('error', _makeError('Failed to request att mtu. A GATT operation already in progress.'));
             return;
         }
 
         this._adapter.gattcExchangeMtuRequest(device.connectionHandle, mtu, err => {
             if (err) {
-                const errorObject = _makeError('Failed to request att mtu', err);
+                const errorObject = _makeError(`Failed to request att mtu: ${err.message}`);
                 if (callback) callback(errorObject);
                 return;
             }
 
-            this._gattOperationsMap[device.instanceId] = { callback: callback, clientRxMtu: mtu };
+            this._gattOperationsMap[device.instanceId] = { callback, clientRxMtu: mtu };
         });
     }
 


### PR DESCRIPTION
The `_makeError` function in adapter.js accepts a second parameter that, according to the JSDoc, is used for error details. However, this is not used consistently. Sometimes a string is given here, and sometimes an error object is given. This makes it difficult to use, as we don't know what type we are dealing with.

Including error details in the main message instead.