### PR TITLE
Include disturl when building for electron

### DIFF
--- a/scripts/publish-all-prebuilt.js
+++ b/scripts/publish-all-prebuilt.js
@@ -46,9 +46,19 @@ const spawn = require('child_process').spawn;
  */
 
 const BUILD_CONFIGS = [
-    { npm_config_runtime: 'node', npm_config_target: '8.9.1' },
-    { npm_config_runtime: 'node', npm_config_target: '6.12.0' },
-    { npm_config_runtime: 'electron', npm_config_target: '1.6.7' },
+    {
+        npm_config_runtime: 'node',
+        npm_config_target: '8.9.1',
+    },
+    {
+        npm_config_runtime: 'node',
+        npm_config_target: '6.12.0',
+    },
+    {
+        npm_config_runtime: 'electron',
+        npm_config_target: '1.6.7',
+        npm_config_disturl: 'https://atom.io/download/electron',
+    },
 ];
 
 function runNpm(args, envVars) {


### PR DESCRIPTION
Including the disturl that points to the header files for electron. Ref: https://github.com/electron/electron/blob/master/docs/tutorial/using-native-node-modules.md.