### PR TITLE
Align default options for enabling BLE

### DIFF
--- a/api/adapter.js
+++ b/api/adapter.js
@@ -320,6 +320,27 @@ class Adapter extends EventEmitter {
         }
     }
 
+    _getDefaultEnableBLEParams() {
+        return {
+            gap_enable_params: {
+                periph_conn_count: 1,
+                central_conn_count: 7,
+                central_sec_count: 1,
+            },
+            gatts_enable_params: {
+                service_changed: false,
+                attr_tab_size: this._bleDriver.BLE_GATTS_ATTR_TAB_SIZE_DEFAULT,
+            },
+            common_enable_params: {
+                conn_bw_counts: null, // tell SD to use default
+                vs_uuid_count: 10,
+            },
+            gatt_enable_params: {
+                att_mtu: 247, // 247 is max att mtu size
+            },
+        };
+    }
+
     /**
      * @summary Initialize the adapter.
      *
@@ -383,6 +404,7 @@ class Adapter extends EventEmitter {
         options.logCallback = this._logCallback.bind(this);
         options.eventCallback = this._eventCallback.bind(this);
         options.statusCallback = this._statusCallback.bind(this);
+        options.enableBLEParams = this._getDefaultEnableBLEParams();
 
         this._adapter.open(this._state.port, options, err => {
             if (this._checkAndPropagateError(err, 'Error occurred opening serial port.', callback)) { return; }
@@ -495,24 +517,7 @@ class Adapter extends EventEmitter {
      */
     enableBLE(options, callback) {
         if (options === undefined || options === null) {
-            options = {
-                gap_enable_params: {
-                    periph_conn_count: 1,
-                    central_conn_count: 7,
-                    central_sec_count: 1,
-                },
-                gatts_enable_params: {
-                    service_changed: false,
-                    attr_tab_size: this._bleDriver.BLE_GATTS_ATTR_TAB_SIZE_DEFAULT,
-                },
-                common_enable_params: {
-                    conn_bw_counts: null, // tell SD to use default
-                    vs_uuid_count: 10,
-                },
-                gatt_enable_params: {
-                    att_mtu: 247, // 247 is max att mtu size
-                },
-            };
+            options = this._getDefaultEnableBLEParams();
         }
 
         this._adapter.enableBLE(

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -213,7 +213,7 @@ private:
     static void initGattS(v8::Local<v8::FunctionTemplate> tpl);
 
     void dispatchEvents();
-    static uint32_t enableBLE(adapter_t *adapter);
+    static uint32_t enableBLE(adapter_t *adapter, ble_enable_params_t *ble_enable_params);
 
     void createSecurityKeyStorage(const uint16_t connHandle, ble_gap_sec_keyset_t *keyset);
     void destroySecurityKeyStorage(const uint16_t connHandle);

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -479,7 +479,7 @@ v8::Local<v8::Object> CommonDataLengthChangedEvent::ToJs()
 #endif
 
 // Class private method that is only used by the class to activate the SoftDevice in the Adapter
-uint32_t Adapter::enableBLE(adapter_t *adapter)
+uint32_t Adapter::enableBLE(adapter_t *adapter, ble_enable_params_t *ble_enable_params)
 {
     // If the this->adapter has not been set yet it is because the Adapter::Open call has not set
     // an adapter_t instance. The SoftDevice is started in Adapter::Open call and we do not have to
@@ -489,18 +489,7 @@ uint32_t Adapter::enableBLE(adapter_t *adapter)
         return NRF_ERROR_INVALID_PARAM;
     }
 
-    ble_enable_params_t ble_enable_params;
-
-    memset(&ble_enable_params, 0, sizeof(ble_enable_params));
-
-    ble_enable_params.common_enable_params.vs_uuid_count = 5;
-    ble_enable_params.gap_enable_params.periph_conn_count = 1;
-    ble_enable_params.gap_enable_params.central_sec_count = 1;
-    ble_enable_params.gatts_enable_params.service_changed = false;
-    ble_enable_params.gatts_enable_params.attr_tab_size = BLE_GATTS_ATTR_TAB_SIZE_DEFAULT;
-    ble_enable_params.gap_enable_params.central_conn_count = 7;
-
-    return sd_ble_enable(adapter, &ble_enable_params, 0);
+    return sd_ble_enable(adapter, ble_enable_params, 0);
 }
 
 // This function runs in the Main Thread
@@ -619,12 +608,23 @@ NAN_METHOD(Adapter::Open)
         baton->retransmission_interval = ConversionUtility::getNativeUint32(options, "retransmissionInterval"); parameter++;
         baton->response_timeout = ConversionUtility::getNativeUint32(options, "responseTimeout"); parameter++;
         baton->enable_ble = ConversionUtility::getBool(options, "enableBLE"); parameter++;
+        baton->ble_enable_params = EnableParameters(ConversionUtility::getJsObject(options, "enableBLEParams")); parameter++;
     }
     catch (std::string error)
     {
         std::stringstream errormessage;
         errormessage << "A setup option was wrong. Option: ";
-        const char *_options[] = { "baudrate", "parity", "flowcontrol", "eventInterval", "logLevel", "retransmissionInterval", "responseTimeout", "enableBLE" };
+        const char *_options[] = {
+            "baudrate",
+            "parity",
+            "flowcontrol",
+            "eventInterval",
+            "logLevel",
+            "retransmissionInterval",
+            "responseTimeout",
+            "enableBLE",
+            "enableBLEParams"
+        };
         errormessage << _options[parameter] << ". Reason: " << error;
         Nan::ThrowTypeError(errormessage.str().c_str());
         return;
@@ -722,8 +722,7 @@ void Adapter::Open(uv_work_t *req)
     }
 
     if (baton->enable_ble) {
-        // Enable BLE with default values defined in Adapter:enableBLE private function
-        error_code = Adapter::enableBLE(adapter);
+        error_code = Adapter::enableBLE(adapter, baton->ble_enable_params);
 
         if (error_code == NRF_SUCCESS)
         {

--- a/src/driver.h
+++ b/src/driver.h
@@ -252,7 +252,8 @@ public:
     uint32_t retransmission_interval; // The interval between each retransmission of packet to target
     uint32_t response_timeout; // Duration to wait for reply on reliable packet sent to target
 
-    bool enable_ble; // Enable BLE or not when connecting, if not the developer must enable the the BLE when state is active
+    bool enable_ble; // Enable BLE or not when connecting, if not the developer must enable the BLE when state is active
+    ble_enable_params_t *ble_enable_params; // If enable BLE is true, then use these params when enabling BLE
 
     Adapter *mainObject;
 };


### PR DESCRIPTION
Ref: #92.

There are two ways of enabling BLE:
- Passing `enableBLE: true` as an option to the `adapter.open()` call
- Calling `adapter.enableBLE()` after opening.

When calling `adapter.enableBLE()`, an options object may be specified. If this is not given, then a set of default options are used. When passing `enableBLE: true` to `adapter.open()` it will
always use default options. However, the default options in this case are not the same as the default options for `adapter.enableBLE()`.

Now using the same default options for `enableBLE: true` as for `adapter.enableBLE()`.