### PR TITLE
Move state update to after call to reset function

### DIFF
--- a/api/adapter.js
+++ b/api/adapter.js
@@ -446,15 +446,15 @@ class Adapter extends EventEmitter {
             return;
         }
 
-        this._changeState({
-            available: false,
-            bleEnabled: false,
-        });
-
         this.connReset(err => {
             if (err) {
-                this.emit('logMessage', logLevel.DEBUG, `Failed to issue connectivity reset: ${err}. Proceeding with close.`);
+                this.emit('logMessage', logLevel.DEBUG, `Failed to issue connectivity reset: ${err.message}. Proceeding with close.`);
             }
+
+            this._changeState({
+                available: false,
+                bleEnabled: false,
+            });
 
             this._adapter.close(error => {
                 /**


### PR DESCRIPTION
This PR fixes a problem where the reset function fails because the close function sets the available-state to false *before* calling reset.