### PR TITLE
Bump to v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-ble-driver-js",
-  "version": "2.3.0-alpha.0",
+  "version": "2.3.0",
   "description": "Javascript bindings for pc-ble-driver",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The v2.3.0 release has been published on GitHub and npm. Updating the version number on master.