### PR TITLE
Prevent opening adapter if it is already open

### DIFF
--- a/api/adapterState.js
+++ b/api/adapterState.js
@@ -76,6 +76,12 @@ class AdapterState {
         this.flowControl = null;
 
         /**
+         * Whether the adapter is in the process of being opened.
+         * @type {boolean}
+         */
+        this.opening = false;
+
+        /**
          * Whether the adapter is available and successfully opened.
          * @type {boolean}
          */


### PR DESCRIPTION
Returning an error if `open` is called on an already open adapter.