### PR TITLE
Add FirmwareRegistry for querying connectivity firmware info

### DIFF
--- a/api/__tests__/__snapshots__/firmwareRegistry-test.js.snap
+++ b/api/__tests__/__snapshots__/firmwareRegistry-test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FirmwareRegistry.getJlinkConnectivityFirmware returns expected jlink firmware info for nrf51 and darwin 1`] = `
+Object {
+  "baudRate": 115200,
+  "file": "<PROJECT_ROOT>/pc-ble-driver/hex/sd_api_v2/connectivity_1.2.2_115k2_with_s130_2.0.1.hex",
+  "sdBleApiVersion": 2,
+  "version": "1.2.2",
+}
+`;
+
+exports[`FirmwareRegistry.getJlinkConnectivityFirmware returns expected jlink firmware info for nrf51 and linux 1`] = `
+Object {
+  "baudRate": 1000000,
+  "file": "<PROJECT_ROOT>/pc-ble-driver/hex/sd_api_v2/connectivity_1.2.2_1m_with_s130_2.0.1.hex",
+  "sdBleApiVersion": 2,
+  "version": "1.2.2",
+}
+`;
+
+exports[`FirmwareRegistry.getJlinkConnectivityFirmware returns expected jlink firmware info for nrf51 and win32 1`] = `
+Object {
+  "baudRate": 1000000,
+  "file": "<PROJECT_ROOT>/pc-ble-driver/hex/sd_api_v2/connectivity_1.2.2_1m_with_s130_2.0.1.hex",
+  "sdBleApiVersion": 2,
+  "version": "1.2.2",
+}
+`;
+
+exports[`FirmwareRegistry.getJlinkConnectivityFirmware returns expected jlink firmware info for nrf52 and darwin 1`] = `
+Object {
+  "baudRate": 115200,
+  "file": "<PROJECT_ROOT>/pc-ble-driver/hex/sd_api_v3/connectivity_1.2.2_115k2_with_s132_3.0.hex",
+  "sdBleApiVersion": 3,
+  "version": "1.2.2",
+}
+`;
+
+exports[`FirmwareRegistry.getJlinkConnectivityFirmware returns expected jlink firmware info for nrf52 and linux 1`] = `
+Object {
+  "baudRate": 1000000,
+  "file": "<PROJECT_ROOT>/pc-ble-driver/hex/sd_api_v3/connectivity_1.2.2_1m_with_s132_3.0.hex",
+  "sdBleApiVersion": 3,
+  "version": "1.2.2",
+}
+`;
+
+exports[`FirmwareRegistry.getJlinkConnectivityFirmware returns expected jlink firmware info for nrf52 and win32 1`] = `
+Object {
+  "baudRate": 1000000,
+  "file": "<PROJECT_ROOT>/pc-ble-driver/hex/sd_api_v3/connectivity_1.2.2_1m_with_s132_3.0.hex",
+  "sdBleApiVersion": 3,
+  "version": "1.2.2",
+}
+`;
+
+exports[`FirmwareRegistry.getNordicUSBConnectivityFirmware returns expected nordicUsb firmware info for darwin 1`] = `undefined`;
+
+exports[`FirmwareRegistry.getNordicUSBConnectivityFirmware returns expected nordicUsb firmware info for linux 1`] = `undefined`;
+
+exports[`FirmwareRegistry.getNordicUSBConnectivityFirmware returns expected nordicUsb firmware info for win32 1`] = `undefined`;

--- a/api/__tests__/firmwareRegistry-test.js
+++ b/api/__tests__/firmwareRegistry-test.js
@@ -1,0 +1,149 @@
+/* Copyright (c) 2010 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const FirmwareRegistry = require('../firmwareRegistry');
+
+describe('FirmwareRegistry.getJlinkConnectivityFirmware', () => {
+    it('throws error if unknown family was supplied', () => {
+        expect(() => FirmwareRegistry.getJlinkConnectivityFirmware('nrf50'))
+            .toThrowError('Unsupported family: nrf50. Expected one of ["nrf51","nrf52"]');
+    });
+
+    it('returns expected jlink firmware info for nrf51 and win32', () => {
+        expect(FirmwareRegistry.getJlinkConnectivityFirmware('nrf51', 'win32'))
+            .toMatchSnapshot();
+    });
+
+    it('returns expected jlink firmware info for nrf51 and linux', () => {
+        expect(FirmwareRegistry.getJlinkConnectivityFirmware('nrf51', 'linux'))
+            .toMatchSnapshot();
+    });
+
+    it('returns expected jlink firmware info for nrf51 and darwin', () => {
+        expect(FirmwareRegistry.getJlinkConnectivityFirmware('nrf51', 'darwin'))
+            .toMatchSnapshot();
+    });
+
+    it('returns expected jlink firmware info for nrf52 and win32', () => {
+        expect(FirmwareRegistry.getJlinkConnectivityFirmware('nrf52', 'win32'))
+            .toMatchSnapshot();
+    });
+
+    it('returns expected jlink firmware info for nrf52 and linux', () => {
+        expect(FirmwareRegistry.getJlinkConnectivityFirmware('nrf52', 'linux'))
+            .toMatchSnapshot();
+    });
+
+    it('returns expected jlink firmware info for nrf52 and darwin', () => {
+        expect(FirmwareRegistry.getJlinkConnectivityFirmware('nrf52', 'darwin'))
+            .toMatchSnapshot();
+    });
+});
+
+describe('FirmwareRegistry.getNordicUSBConnectivityFirmware', () => {
+    it('returns expected nordicUsb firmware info for win32', () => {
+        expect(FirmwareRegistry.getNordicUsbConnectivityFirmware('win32'))
+            .toMatchSnapshot();
+    });
+
+    it('returns expected nordicUsb firmware info for linux', () => {
+        expect(FirmwareRegistry.getNordicUsbConnectivityFirmware('linux'))
+            .toMatchSnapshot();
+    });
+
+    it('returns expected nordicUsb firmware info for darwin', () => {
+        expect(FirmwareRegistry.getNordicUsbConnectivityFirmware('darwin'))
+            .toMatchSnapshot();
+    });
+});
+
+describe('FirmwareRegistry.parseVersionStruct', () => {
+    it('returns empty object if version struct is empty', () => {
+        const versionInfo = FirmwareRegistry.parseVersionStruct([]);
+        expect(versionInfo).toEqual({});
+    });
+
+    it('returns empty object if version struct does not contain magic', () => {
+        const versionInfo = FirmwareRegistry.parseVersionStruct([0, 2, 3, 4]);
+        expect(versionInfo).toEqual({});
+    });
+
+    it('returns empty object if version struct contains magic but has length < 24', () => {
+        const struct = [
+            23, 165, 216, 70, // magic
+            2,                // struct version
+            255, 255, 255,    // (reserved for future use)
+            0, 0, 0, 0,       // revision hash
+            1,                // version major
+            1,                // version minor
+            0,                // version patch
+            255,              // (reserved for future use)
+            3,                // softdevice ble api number
+            1,                // transport type
+            255, 255,         // (reserved for future use)
+            64, 66, 15,       // baud rate
+        ];
+        const versionInfo = FirmwareRegistry.parseVersionStruct(struct);
+        expect(versionInfo).toEqual({});
+    });
+
+    it('returns correct version, softdevice version, transport type, and baud rate', () => {
+        const struct = [
+            23, 165, 216, 70, // magic
+            2,                // struct version
+            255, 255, 255,    // (reserved for future use)
+            0, 0, 0, 0,       // revision hash
+            0,                // version major
+            1,                // version minor
+            2,                // version patch
+            255,              // (reserved for future use)
+            3,                // softdevice ble api number
+            1,                // transport type
+            255, 255,         // (reserved for future use)
+            64, 66, 15, 0,    // baud rate
+        ];
+        const versionInfo = FirmwareRegistry.parseVersionStruct(struct);
+        expect(versionInfo).toEqual({
+            version: '0.1.2',
+            sdBleApiVersion: 3,
+            transportType: 1,
+            baudRate: 1000000,
+        });
+    });
+});
+

--- a/api/__tests__/firmwareUpdater-test.js
+++ b/api/__tests__/firmwareUpdater-test.js
@@ -114,12 +114,7 @@ describe('FirmwareUpdater.parseVersionStruct', () => {
 describe('FirmwareUpdater.getFirmwarePath', () => {
     it('throws error if unknown family was supplied', () => {
         expect(() => FirmwareUpdater.getFirmwarePath(-1, 'linux'))
-            .toThrowError('Unsupported family: -1. Expected one of ["0","1"]');
-    });
-
-    it('throws error if unknown platform was supplied', () => {
-        expect(() => FirmwareUpdater.getFirmwarePath(0, 'windooze'))
-            .toThrowError('Unsupported platform: windooze. Expected one of ["win32","linux","darwin"]');
+            .toThrowError('Unsupported family: -1. Expected one of 0 or 1.');
     });
 
     it('returns v2/1m hex path for nrf51 and win32', () => {
@@ -156,12 +151,7 @@ describe('FirmwareUpdater.getFirmwarePath', () => {
 describe('FirmwareUpdater.getLatestVersion', () => {
     it('throws error if unknown family was supplied', () => {
         expect(() => FirmwareUpdater.getLatestVersion(-1, 'linux'))
-            .toThrowError('Unsupported family: -1. Expected one of ["0","1"]');
-    });
-
-    it('throws error if unknown platform was supplied', () => {
-        expect(() => FirmwareUpdater.getLatestVersion(0, 'windooze'))
-            .toThrowError('Unsupported platform: windooze. Expected one of ["win32","linux","darwin"]');
+            .toThrowError('Unsupported family: -1. Expected one of 0 or 1.');
     });
 
     it('returns latest version for nrf51 and linux', () => {
@@ -174,12 +164,7 @@ describe('FirmwareUpdater.getLatestVersion', () => {
 describe('FirmwareUpdater.getBaudRate', () => {
     it('throws error if unknown family was supplied', () => {
         expect(() => FirmwareUpdater.getBaudRate(-1, 'linux'))
-            .toThrowError('Unsupported family: -1. Expected one of ["0","1"]');
-    });
-
-    it('throws error if unknown platform was supplied', () => {
-        expect(() => FirmwareUpdater.getBaudRate(0, 'windooze'))
-            .toThrowError('Unsupported platform: windooze. Expected one of ["win32","linux","darwin"]');
+            .toThrowError('Unsupported family: -1. Expected one of 0 or 1.');
     });
 
     it('returns 1m for nrf51 and win32', () => {

--- a/api/firmwareRegistry.js
+++ b/api/firmwareRegistry.js
@@ -1,0 +1,236 @@
+/* Copyright (c) 2010 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const arrayToInt = require('./util/intArrayConv').arrayToInt;
+
+const currentDir = require.resolve('./firmwareRegistry');
+const hexDir = path.join(currentDir, '..', '..', 'pc-ble-driver', 'hex');
+const sdV2Dir = path.join(hexDir, 'sd_api_v2');
+const sdV3Dir = path.join(hexDir, 'sd_api_v3');
+
+const VERSION_INFO_MAGIC = 0x46D8A517;
+const VERSION_INFO_START = 0x20000;
+const VERSION_INFO_LENGTH = 24;
+
+/*
+ * Holds connectivity firmware information for all supported devices.
+ *
+ * Devices that have a J-Link debug probe are programmed using nrfjprog, and
+ * have only one firmware hex file. Devices that use the Nordic USB stack
+ * are programmed using serial DFU. In this case, we need two hex files: One
+ * for the softdevice and one for the connectivity application.
+ *
+ * MacOS does not support opening serial ports using baud rates higher than
+ * 115200, while Windows and Linux supports 1m. This requires separate
+ * connectivity firmwares and baud rate settings for the different OS'es.
+ */
+function getFirmwareMap(platform) {
+    return {
+        jlink: {
+            nrf51: {
+                file: platform === 'darwin' ?
+                    path.join(sdV2Dir, 'connectivity_1.2.2_115k2_with_s130_2.0.1.hex') :
+                    path.join(sdV2Dir, 'connectivity_1.2.2_1m_with_s130_2.0.1.hex'),
+                version: '1.2.2',
+                baudRate: platform === 'darwin' ? 115200 : 1000000,
+                sdBleApiVersion: 2,
+            },
+            nrf52: {
+                file: platform === 'darwin' ?
+                    path.join(sdV3Dir, 'connectivity_1.2.2_115k2_with_s132_3.0.hex') :
+                    path.join(sdV3Dir, 'connectivity_1.2.2_1m_with_s132_3.0.hex'),
+                version: '1.2.2',
+                baudRate: platform === 'darwin' ? 115200 : 1000000,
+                sdBleApiVersion: 3,
+            },
+        },
+        nordicUsb: {
+            /*
+            pca10059: {
+                files: {
+                    application: path.join(sdV3Dir, 'connectivity.hex'),
+                    softdevice: path.join(sdV3Dir, 'softdevice.hex'),
+                },
+                version: 'connectivity x.y.z',
+                baudRate: platform === 'darwin' ? 115200 : 1000000,
+                sdBleApiVersion: 3,
+            },
+            */
+        },
+    };
+}
+
+/**
+ * Exposes connectivity firmware information to the consumer of pc-ble-driver-js.
+ * Implemented as a class with static functions in order to stay consistent with
+ * the rest of the pc-ble-driver-js API.
+ */
+class FirmwareRegistry {
+
+    /**
+     * Get connectivity firmware information for the given device family.
+     * Returns an object on the form:
+     * {
+     *   file: '/path/to/firmware.hex',
+     *   version: '1.2.2',
+     *   baudRate: 115200,
+     *   sdBleApiVersion: 2,
+     * }
+     *
+     * @param {String} family The device family. One of 'nrf51' or 'nrf52'.
+     * @param {String} [platform] Optional value that can be one of 'win32',
+     *     'linux', 'darwin'. Will use the detected platform if not provided.
+     * @returns {Object} Firmware info object as described above.
+     */
+    static getJlinkConnectivityFirmware(family, platform) {
+        const firmwareMap = getFirmwareMap(platform || process.platform);
+        if (!firmwareMap.jlink[family]) {
+            throw new Error(`Unsupported family: ${family}. ` +
+                `Expected one of ${JSON.stringify(Object.keys(firmwareMap.jlink))}`);
+        }
+        return firmwareMap.jlink[family];
+    }
+
+    /**
+     * Get connectivity firmware information for Nordic USB devices.
+     * Returns an object on the form:
+     * {
+     *   files: {
+     *     application: '/path/to/application.hex',
+     *     softdevice: '/path/to/softdevice.hex',
+     *   },
+     *   version: 'connectivity 1.2.2+dfuMar-27-2018-12-41-04',
+     *   baudRate: 115200,
+     *   sdBleApiVersion: 3,
+     * }
+     *
+     * @param {String} [platform] Optional value that can be one of 'win32',
+     *     'linux', 'darwin'. Will use the detected platform if not provided.
+     * @returns {Object} Firmware info object as described above.
+     */
+    static getNordicUsbConnectivityFirmware(platform) {
+        const firmwareMap = getFirmwareMap(platform || process.platform);
+        return firmwareMap.nordicUsb.pca10059;
+    }
+
+    /**
+     * Returns an object that can be passed to the nrf-device-setup npm library
+     * for setting up the device. See https://www.npmjs.com/package/nrf-device-setup
+     * for a description of the returned object format.
+     *
+     * @param {String} [platform] Optional value that can be one of 'win32',
+     *     'linux', 'darwin'. Will use the detected platform if not provided.
+     * @returns {Object} Device setup object.
+     */
+    static getDeviceSetup(platform) {
+        const firmwareMap = getFirmwareMap(platform || process.platform);
+
+        const config = {
+            jprog: {},
+            dfu: {},
+        };
+
+        Object.keys(firmwareMap.jlink).forEach(family => {
+            const deviceConfig = firmwareMap.jlink[family];
+            const buffer = fs.readFileSync(deviceConfig.file);
+            Object.assign(config.jprog, {
+                [family]: {
+                    fw: buffer,
+                    fwVersion: {
+                        length: VERSION_INFO_LENGTH,
+                        validator: data => {
+                            const parsedData = FirmwareRegistry.parseVersionStruct(data);
+                            return parsedData.version === deviceConfig.version &&
+                                parsedData.baudRate === deviceConfig.baudRate;
+                        },
+                    },
+                    fwIdAddress: VERSION_INFO_START,
+                },
+            });
+        });
+
+        Object.keys(firmwareMap.nordicUsb).forEach(deviceType => {
+            const deviceConfig = firmwareMap.nordicUsb[deviceType];
+            const applicationBuffer = fs.readFileSync(deviceConfig.files.application);
+            const softdeviceBuffer = fs.readFileSync(deviceConfig.files.softdevice);
+            Object.assign(config.dfu, {
+                [deviceType]: {
+                    application: applicationBuffer,
+                    softdevice: softdeviceBuffer,
+                    semver: deviceConfig.version,
+                },
+            });
+        });
+
+        return config;
+    }
+
+    /**
+     * Parse the version info struct that can be found in the connectivity
+     * firmware. See the connectivity firmware patch in pc-ble-driver/hex/sd_api_v*
+     * for details.
+     *
+     * @param {Number[]} versionStruct Array of integers from the firmware.
+     * @returns {Object} Parsed version info struct as an object.
+     */
+    static parseVersionStruct(versionStruct) {
+        const magic = arrayToInt(versionStruct.slice(0, 4));
+        const isValid = versionStruct.length === VERSION_INFO_LENGTH
+            && magic === VERSION_INFO_MAGIC;
+        if (!isValid) {
+            return {};
+        }
+        const major = versionStruct[12];
+        const minor = versionStruct[13];
+        const patch = versionStruct[14];
+        const version = `${major}.${minor}.${patch}`;
+        const sdBleApiVersion = versionStruct[16];
+        const transportType = versionStruct[17];
+        const baudRate = arrayToInt(versionStruct.slice(20, 24));
+        return {
+            version,
+            sdBleApiVersion,
+            transportType,
+            baudRate,
+        };
+    }
+}
+
+module.exports = FirmwareRegistry;

--- a/api/firmwareRegistry.js
+++ b/api/firmwareRegistry.js
@@ -178,6 +178,7 @@ class FirmwareRegistry {
                         validator: data => {
                             const parsedData = FirmwareRegistry.parseVersionStruct(data);
                             return parsedData.version === deviceConfig.version &&
+                                parsedData.sdBleApiVersion === deviceConfig.sdBleApiVersion &&
                                 parsedData.baudRate === deviceConfig.baudRate;
                         },
                     },

--- a/config/jest-unit.config
+++ b/config/jest-unit.config
@@ -1,4 +1,7 @@
 {
   "roots": ["api"],
-  "testResultsProcessor": "jest-bamboo-formatter"
+  "testResultsProcessor": "jest-bamboo-formatter",
+  "snapshotSerializers": [
+    "jest-serializer-path"
+  ]
 }

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ const Characteristic = require('./api/characteristic');
 const Descriptor = require('./api/descriptor');
 const Device = require('./api/device');
 const Dfu = require('./api/dfu');
+const FirmwareRegistry = require('./api/firmwareRegistry');
 const FirmwareUpdater = require('./api/firmwareUpdater');
 const Security = require('./api/security');
 const Service = require('./api/service');
@@ -54,6 +55,7 @@ module.exports = {
     Descriptor,
     Device,
     Dfu,
+    FirmwareRegistry,
     FirmwareUpdater,
     Security,
     Service,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "gh-pages": "^1.0.0",
     "jest": "^19.0.2",
     "jest-bamboo-formatter": "0.0.3",
+    "jest-serializer-path": "^0.1.14",
     "jscs": "^2.3.5",
     "jsdoc": "^3.4.3",
     "jshint": "^2.8.0",


### PR DESCRIPTION
We have multiple connectivity hex files and different combination of baud rates and SoftDevice versions depending on the device type and OS. More hex files will be added soon, and it is difficult to keep track of all these combinations.

I propose adding a `FirmwareRegistry` as an authoritative source of all information related to connectivity firmwares. We can then query this registry to figure out which firmware file, baud rate, SoftDevice version to use together with a given device family:

```
const { FirmwareRegistry } = require('pc-ble-driver-js');

const nrf52Fw = FirmwareRegistry.getJlinkConnectivityFirmware('nrf52');
console.log(nrf52Fw);

// Output:
// {
//   file: '/path/to/connectivity_1.2.2_1m_with_s132_3.0.hex',
//   version: '1.2.2',
//   baudRate: 1000000,
//   sdBleApiVersion: 3
// }

const nordicUsbFw = FirmwareRegistry.getNordicUsbConnectivityFirmware();
console.log(nordicUsbFw);

// Output:
// {
//   files: {
//     application: '/path/to/application.hex',
//     softdevice: '/path/to/softdevice.hex',
//   },
//   version: 'connectivity x.y.z+dfuyyyy-mm-dd',
//   baudRate: 1000000,
//   sdBleApiVersion: 3
// }
```

There is already a FirmwareUpdater class that has some of the same functionality, but this only supports firmwares for J-Link devices. This is now deprecated, and will be replaced by the nrf-device-setup library. Keeping the FirmwareUpdater for backwards compatibility.

The FirmwareRegistry also has a `getDeviceSetup()` function that returns connectivity firmware information as an object that can be passed directly to the nrf-device-setup library:

```
const { setupDevice } = require('nrf-device-setup');
const { FirmwareRegistry } = require('pc-ble-driver-js');

setupDevice(device, FirmwareRegistry.getDeviceSetup());
```

I am not sure if it is a good idea to expose this `getDeviceSetup()` function through the API, and would appreciate your feedback on this. It is probably useful for the consumer, and will allow us to reuse the device setup generation, but it is maybe a bit too magical.