### PR TITLE
Fix wrong property name in FirmwareUpdater

### DIFF
--- a/api/firmwareUpdater.js
+++ b/api/firmwareUpdater.js
@@ -184,7 +184,7 @@ class FirmwareUpdater {
                 const familyString = getFamilyString(family);
                 const firmwareInfo = FirmwareRegistry.getJlinkConnectivityFirmware(familyString, platform);
                 const isUpdateRequired =
-                    info.version !== firmwareInfo.firmwareVersion ||
+                    info.version !== firmwareInfo.version ||
                     info.baudRate !== firmwareInfo.baudRate;
                 return Object.assign({}, info, { isUpdateRequired });
             });


### PR DESCRIPTION
A bug was introduced in #151, causing `isUpdateRequired` in `FirmwareUpdater` to always return true. This PR fixes it.