### PR TITLE
Use pc-ble-driver v2.3.0 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pc-ble-driver"]
 	path = pc-ble-driver
 	url = https://github.com/NordicSemiconductor/pc-ble-driver.git
-	branch = v2.2.1
+	branch = release/v2.3.0


### PR DESCRIPTION
Updating the pc-ble-driver submodule to point to the `release/v2.3.0` branch.