### PR TITLE
Add ability to set pc-ble-driver log levels based on options and env var

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -317,7 +317,7 @@ function addAdapterListener(adapter, prefix) {
  * @param {boolean} [programDevice] set to false to not program the device before starting to use it
  * @param {string} [family] only use devices of a given family
  * @param {string} [blacklist] list of devices to not use in tests
- * @param {string} [logLevel] set log level that shall be used in pc-ble-driver. Can be trace, debug, info, error, fatal.
+ * @param {string} [logLevel] set log level that shall be used in pc-ble-driver. Can be "trace", "debug", "info", "error", "fatal".
  */
 
 /**


### PR DESCRIPTION
There is a need to capture more detailed information from pc-ble-driver when running integration tests.

This PR makes it possible to specify pc-ble-driver log levels based on options provided on setup or through environment variables.