### PR TITLE
Update call to sd_rpc_conn_reset with new argument

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -842,14 +842,16 @@ NAN_METHOD(Adapter::ConnReset)
     auto baton = new ConnResetBaton(callback);
     baton->adapter = obj->adapter;
     baton->mainObject = obj;
+    /* Hardcoding the reset mode. Consider adding argument for letting user choose reset mode. */
+    baton->reset = SOFT_RESET;
 
     uv_queue_work(uv_default_loop(), baton->req, ConnReset, reinterpret_cast<uv_after_work_cb>(AfterConnReset));
 }
 
 void Adapter::ConnReset(uv_work_t *req)
 {
-    auto baton = static_cast<CloseBaton *>(req->data);
-    baton->result = sd_rpc_conn_reset(baton->adapter);
+    auto baton = static_cast<ConnResetBaton *>(req->data);
+    baton->result = sd_rpc_conn_reset(baton->adapter, baton->reset);
 }
 
 void Adapter::AfterConnReset(uv_work_t *req)

--- a/src/driver.h
+++ b/src/driver.h
@@ -269,6 +269,7 @@ struct ConnResetBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(ConnResetBaton);
+    sd_rpc_reset_t reset;
     Adapter *mainObject;
 };
 


### PR DESCRIPTION
This PR is to make pc-ble-driver-js compatible with new signature of sd_rpc_conn_reset