### PR TITLE
Remove cleanup of V8 resources used in AddOn when calling Adapter.connReset

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -859,8 +859,6 @@ void Adapter::AfterConnReset(uv_work_t *req)
     Nan::HandleScope scope;
     auto baton = static_cast<ConnResetBaton *>(req->data);
 
-    baton->mainObject->cleanUpV8Resources();
-
     if (baton->callback != nullptr)
     {
         v8::Local<v8::Value> argv[1];

--- a/src/driver_gap.cpp
+++ b/src/driver_gap.cpp
@@ -395,7 +395,7 @@ ble_gap_conn_sec_t *GapConnSec::ToNative()
 ble_gap_opt_t *GapOpt::ToNative()
 {
     auto gap_opt = new ble_gap_opt_t();
-    memset(gap_opt, 0, sizeof(gap_opt));
+    memset(gap_opt, 0, sizeof(ble_gap_opt_t));
 
     if (Utility::Has(jsobj, "scan_req_report"))
     {


### PR DESCRIPTION
By cleaning up the V8 resources when calling Adapter.connReset, information is lost.
The event, status, log will not be sent to JS, making it harder to debug what happens after a connReset.

The V8 resources are cleaned up when calling Adapter.close.