### PR TITLE
Tune integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nan": "2.3.3",
     "node-pre-gyp": "^0.6.39",
     "nrf-device-lister": "2.0.0",
-    "nrf-device-setup": "0.2.4",
+    "nrf-device-setup": "0.2.5",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nan": "2.3.3",
     "node-pre-gyp": "^0.6.39",
     "nrf-device-lister": "2.0.0",
-    "nrf-device-setup": "0.2.0",
+    "nrf-device-setup": "0.2.4",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,7 @@ The following environment variables affects the running of the tests:
 | ------------------------------| ---------------------------------------------------------------------------------|
 PC_BLE_DRIVER_TEST_BLACKLIST    | A list of devices serial numbers to not use in the tests. Separate multiple devices with comma. | 
 PC_BLE_DRIVER_TEST_FAMILY       | The device family to use for the tests, can be nrf51 or nrf52.                   |
-PC_BLE_DRIVER_TEST_SKIP_PROGRAMMING | Skip programming of devices in tests. Assumes that correct firmware is in place. |
+PC_BLE_DRIVER_TEST_SKIP_PROGRAMMING | Set to true to skip programming of devices in tests. Assumes that correct firmware is in place. |
 PC_BLE_DRIVER_TEST_OPENCLOSE    | The number of iterations the openClose test shall run. It defaults to 2000 runs. |
 PC_BLE_DRIVER_TEST_LOGLEVEL     | Specifies the pc-ble-driver log level. Defaults to 'info'. Can be 'trace', 'debug','info','warning','error','fatal'.|
 DEBUG                           | From debug module. Specifies logger to output/not output on console. See [debug](https://www.npmjs.com/package/debug) for more details. Example loggers: ble-driver:log, ble-driver:test.| 

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,16 @@
+# Running tests
+The tests in this directory must be ran individually since there is an issue with the usb module in combination with jest.
+
+For example:
+`jest advertise.test.js`
+
+## Environment variables
+The following environment variables affects the running of the tests:
+
+  
+| Environment variable          | Description                                                                      |
+| ------------------------------| ---------------------------------------------------------------------------------|
+PC_BLE_DRIVER_TEST_BLACKLIST    | A list of devices serial numbers to not use in the tests. Separate multiple devices with comma | 
+PC_BLE_DRIVER_TEST_FAMILY       | The device family to use for the tests, can be nrf51 or nrf52.                   |
+PC_BLE_DRIVER_TEST_OPENCLOSE    | The number of iterations the openClose test shall run. It defaults to 2000 runs. |
+PC_BLE_DRIVER_TEST_LOGLEVEL     | Specifies the pc-ble-driver log level. Defaults to 'info'. Can be 'trace', 'debug','info','warning','error','fatal'.|

--- a/test/README.md
+++ b/test/README.md
@@ -12,6 +12,7 @@ The following environment variables affects the running of the tests:
 | ------------------------------| ---------------------------------------------------------------------------------|
 PC_BLE_DRIVER_TEST_BLACKLIST    | A list of devices serial numbers to not use in the tests. Separate multiple devices with comma. | 
 PC_BLE_DRIVER_TEST_FAMILY       | The device family to use for the tests, can be nrf51 or nrf52.                   |
+PC_BLE_DRIVER_TEST_SKIP_PROGRAMMING | Skip programming of devices in tests. Assumes that correct firmware is in place. |
 PC_BLE_DRIVER_TEST_OPENCLOSE    | The number of iterations the openClose test shall run. It defaults to 2000 runs. |
 PC_BLE_DRIVER_TEST_LOGLEVEL     | Specifies the pc-ble-driver log level. Defaults to 'info'. Can be 'trace', 'debug','info','warning','error','fatal'.|
 DEBUG                           | From debug module. Specifies logger to output/not output on console. See [debug](https://www.npmjs.com/package/debug) for more details. Example loggers: ble-driver:log, ble-driver:test.| 

--- a/test/README.md
+++ b/test/README.md
@@ -8,11 +8,11 @@ For example:
 The following environment variables affects the running of the tests:
 
   
-| Environment variable          | Description                                                                      |
-| ------------------------------| ---------------------------------------------------------------------------------|
-PC_BLE_DRIVER_TEST_BLACKLIST    | A list of devices serial numbers to not use in the tests. Separate multiple devices with comma. | 
-PC_BLE_DRIVER_TEST_FAMILY       | The device family to use for the tests, can be nrf51 or nrf52.                   |
-PC_BLE_DRIVER_TEST_SKIP_PROGRAMMING | Set to true to skip programming of devices in tests. Assumes that correct firmware is in place. |
-PC_BLE_DRIVER_TEST_OPENCLOSE    | The number of iterations the openClose test shall run. It defaults to 2000 runs. |
-PC_BLE_DRIVER_TEST_LOGLEVEL     | Specifies the pc-ble-driver log level. Defaults to 'info'. Can be 'trace', 'debug','info','warning','error','fatal'.|
-DEBUG                           | From debug module. Specifies logger to output/not output on console. See [debug](https://www.npmjs.com/package/debug) for more details. Example loggers: ble-driver:log, ble-driver:test.| 
+| Environment variable             | Description                                                                                        |
+| ---------------------------------| ---------------------------------------------------------------------------------------------------|
+| BLE_DRIVER_TEST_BLACKLIST        | A list of devices serial numbers to not use in the tests. Separate multiple devices with comma. | 
+| BLE_DRIVER_TEST_FAMILY           | The device family to use for the tests, can be nrf51 or nrf52.                   |
+| BLE_DRIVER_TEST_SKIP_PROGRAMMING | Set to true to skip programming of devices in tests. Assumes that correct firmware is in place. |
+| BLE_DRIVER_TEST_OPENCLOSE        | The number of iterations the openClose test shall run. It defaults to 2000 runs. |
+| BLE_DRIVER_TEST_LOGLEVEL         | Specifies the pc-ble-driver log level. Defaults to 'info'. Can be 'trace', 'debug','info','warning','error','fatal'.|
+| DEBUG                            | From debug module. Specifies logger to output/not output on console. See [debug](https://www.npmjs.com/package/debug) for more details. Example loggers: ble-driver:log, ble-driver:test.| 

--- a/test/README.md
+++ b/test/README.md
@@ -10,7 +10,8 @@ The following environment variables affects the running of the tests:
   
 | Environment variable          | Description                                                                      |
 | ------------------------------| ---------------------------------------------------------------------------------|
-PC_BLE_DRIVER_TEST_BLACKLIST    | A list of devices serial numbers to not use in the tests. Separate multiple devices with comma | 
+PC_BLE_DRIVER_TEST_BLACKLIST    | A list of devices serial numbers to not use in the tests. Separate multiple devices with comma. | 
 PC_BLE_DRIVER_TEST_FAMILY       | The device family to use for the tests, can be nrf51 or nrf52.                   |
 PC_BLE_DRIVER_TEST_OPENCLOSE    | The number of iterations the openClose test shall run. It defaults to 2000 runs. |
 PC_BLE_DRIVER_TEST_LOGLEVEL     | Specifies the pc-ble-driver log level. Defaults to 'info'. Can be 'trace', 'debug','info','warning','error','fatal'.|
+DEBUG                           | From debug module. Specifies logger to output/not output on console. See [debug](https://www.npmjs.com/package/debug) for more details. Example loggers: ble-driver:log, ble-driver:test.| 

--- a/test/advertise.test.js
+++ b/test/advertise.test.js
@@ -38,7 +38,7 @@
 
 const { grabAdapter, releaseAdapter, serviceFactory, setupAdapter } = require('./setup');
 
-const debug = require('debug')('debug');
+const debug = require('debug')('ble-driver:test:advertise');
 
 const PERIPHERAL_DEVICE_ADDRESS = 'FF:11:22:33:AA:CE';
 const PERIPHERAL_DEVICE_ADDRESS_TYPE = 'BLE_GAP_ADDR_TYPE_RANDOM_STATIC';

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -44,7 +44,7 @@ const PERIPHERAL_DEVICE_ADDRESS_TYPE = 'BLE_GAP_ADDR_TYPE_RANDOM_STATIC';
 const CENTRAL_DEVICE_ADDRESS = 'FF:11:22:33:AA:CF';
 const CENTRAL_DEVICE_ADDRESS_TYPE = 'BLE_GAP_ADDR_TYPE_RANDOM_STATIC';
 
-const debug = require('debug')('debug');
+const debug = require('debug')('ble-driver:test:connection');
 
 function connect(adapter, connectToAddress) {
     const options = {

--- a/test/mtu.test.js
+++ b/test/mtu.test.js
@@ -39,7 +39,7 @@
 const { grabAdapter, releaseAdapter, setupAdapter, outcome } = require('./setup');
 
 const api = require('../index');
-const debug = require('debug')('debug');
+const debug = require('debug')('ble-driver:test:mtu');
 
 const serviceFactory = new api.ServiceFactory();
 

--- a/test/openClose.test.js
+++ b/test/openClose.test.js
@@ -43,7 +43,7 @@ const debug = require('debug')('ble-driver:test:open-close');
 const CENTRAL_DEVICE_ADDRESS = 'FF:11:22:33:AA:BE';
 const CENTRAL_DEVICE_ADDRESS_TYPE = 'BLE_GAP_ADDR_TYPE_RANDOM_STATIC';
 
-const NUMBER_OF_ITERATIONS = process.env.PC_BLE_DRIVER_TEST_OPENCLOSE_ITERATIONS ? parseInt(process.env.PC_BLE_DRIVER_TEST_OPENCLOSE_ITERATIONS, 10) : 2000; // Number of open/close iterations
+const NUMBER_OF_ITERATIONS = process.env.BLE_DRIVER_TEST_OPENCLOSE_ITERATIONS ? parseInt(process.env.BLE_DRIVER_TEST_OPENCLOSE_ITERATIONS, 10) : 2000; // Number of open/close iterations
 const NRF51_NRF52_WAIT_TIME = 250; // nRF51/nRF52 based devices require a timeout after a reset
 const SCAN_DURATION = 2000;
 const SCAN_DURATION_WAIT_TIME = 3000;
@@ -82,7 +82,7 @@ function startScan(adapter, timeout) {
 describe('the API', async () => {
     let adapterSn;
     let openCloseIterations = 1;
-    let programDevice = process.env.PC_BLE_DRIVER_TEST_SKIP_PROGRAMMING !== 'true';
+    let programDevice = process.env.BLE_DRIVER_TEST_SKIP_PROGRAMMING !== 'true';
 
     const requiredNumberOfIterations = NUMBER_OF_ITERATIONS || Number.MAX_SAFE_INTEGER;
 

--- a/test/openClose.test.js
+++ b/test/openClose.test.js
@@ -38,15 +38,15 @@
 
 const { grabAdapter, releaseAdapter, setupAdapter, outcome } = require('./setup');
 
-const debug = require('debug')('debug');
+const debug = require('debug')('ble-driver:test:open-close');
 
 const CENTRAL_DEVICE_ADDRESS = 'FF:11:22:33:AA:BE';
 const CENTRAL_DEVICE_ADDRESS_TYPE = 'BLE_GAP_ADDR_TYPE_RANDOM_STATIC';
 
-const NUMBER_OF_ITERATIONS = 2000; // Number of open/close iterations
+const NUMBER_OF_ITERATIONS = process.env.PC_BLE_DRIVER_TEST_OPENCLOSE_ITERATIONS ? parseInt(process.env.PC_BLE_DRIVER_TEST_OPENCLOSE_ITERATIONS, 10) : 2000; // Number of open/close iterations
 const NRF51_NRF52_WAIT_TIME = 250; // nRF51/nRF52 based devices require a timeout after a reset
 const SCAN_DURATION = 2000;
-const SCAN_DURATION_WAIT_TIME = 1500;
+const SCAN_DURATION_WAIT_TIME = 3000;
 const EXPECTED_NUMBER_OF_SCAN_REPORTS_PR_ITERATION = 2;
 
 const GENERIC_WAIT_PR_ITERATION = 1000;
@@ -81,14 +81,14 @@ function startScan(adapter, timeout) {
 
 describe('the API', async () => {
     let adapterSn;
-    let openCloseIterations = 0;
+    let openCloseIterations = 1;
     let programDevice = true;
     let sdApiVersion;
     const requiredNumberOfIterations = NUMBER_OF_ITERATIONS || Number.MAX_SAFE_INTEGER;
 
     it(`shall support opening and closing the adapter ${requiredNumberOfIterations} times.`, async () => {
         const oneIteration = async () => {
-            debug(`Open/close iteration #${openCloseIterations} starting.`);
+            debug(`Open/close iteration #${openCloseIterations} of ${requiredNumberOfIterations} starting.`);
 
             const adapterToUse = await grabAdapter(adapterSn, { programDevice });
 
@@ -137,7 +137,7 @@ describe('the API', async () => {
 
         await new Promise(async (resolve, reject) => {
             try {
-                while (openCloseIterations < requiredNumberOfIterations) {
+                while (openCloseIterations <= requiredNumberOfIterations) {
                     // eslint-disable-next-line no-await-in-loop
                     await oneIteration();
                     // eslint-disable-next-line no-await-in-loop

--- a/test/openClose.test.js
+++ b/test/openClose.test.js
@@ -82,8 +82,8 @@ function startScan(adapter, timeout) {
 describe('the API', async () => {
     let adapterSn;
     let openCloseIterations = 1;
-    let programDevice = true;
-    let sdApiVersion;
+    let programDevice = process.env.PC_BLE_DRIVER_TEST_SKIP_PROGRAMMING !== 'true';
+
     const requiredNumberOfIterations = NUMBER_OF_ITERATIONS || Number.MAX_SAFE_INTEGER;
 
     it(`shall support opening and closing the adapter ${requiredNumberOfIterations} times.`, async () => {
@@ -95,7 +95,6 @@ describe('the API', async () => {
             // Program/check for correct firmware only once
             programDevice = false;
             adapterSn = adapterToUse.state.serialNumber;
-            sdApiVersion = adapterToUse.driver.NRF_SD_BLE_API_VERSION;
 
             await setupAdapter(adapterToUse, 'central', 'central', CENTRAL_DEVICE_ADDRESS, CENTRAL_DEVICE_ADDRESS_TYPE);
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -359,7 +359,7 @@ function mergeOptions(options) {
     }
 
     if (!newOptions.programDevice) {
-        newOptions.programDevice = process.env.PC_BLE_DRIVER_TEST_SKIP_PROGRAMMING == null;
+        newOptions.programDevice = process.env.PC_BLE_DRIVER_TEST_SKIP_PROGRAMMING !== 'true';
     }
 
     if (newOptions.family == null && process.env.PC_BLE_DRIVER_TEST_FAMILY) {

--- a/test/setup.js
+++ b/test/setup.js
@@ -355,19 +355,19 @@ function mergeOptions(options) {
     const newOptions = Object.assign({}, options);
 
     if (!newOptions.logLevel) {
-        newOptions.logLevel = process.env.PC_BLE_DRIVER_TEST_LOGLEVEL || 'info';
+        newOptions.logLevel = process.env.BLE_DRIVER_TEST_LOGLEVEL || 'info';
     }
 
     if (!newOptions.programDevice) {
-        newOptions.programDevice = process.env.PC_BLE_DRIVER_TEST_SKIP_PROGRAMMING !== 'true';
+        newOptions.programDevice = process.env.BLE_DRIVER_TEST_SKIP_PROGRAMMING !== 'true';
     }
 
-    if (newOptions.family == null && process.env.PC_BLE_DRIVER_TEST_FAMILY) {
-        newOptions.family = process.env.PC_BLE_DRIVER_TEST_FAMILY;
+    if (newOptions.family == null && process.env.BLE_DRIVER_TEST_FAMILY) {
+        newOptions.family = process.env.BLE_DRIVER_TEST_FAMILY;
     }
 
-    if (newOptions.blacklist == null && process.env.PC_BLE_DRIVER_TEST_BLACKLIST) {
-        newOptions.blacklist = process.env.PC_BLE_DRIVER_TEST_BLACKLIST.split(',');
+    if (newOptions.blacklist == null && process.env.BLE_DRIVER_TEST_BLACKLIST) {
+        newOptions.blacklist = process.env.BLE_DRIVER_TEST_BLACKLIST.split(',');
     }
 
     return newOptions;

--- a/test/setup.js
+++ b/test/setup.js
@@ -49,7 +49,7 @@ const serviceFactory = new api.ServiceFactory();
 const testTimeout = 2000;
 
 const debug = require('debug')('ble-driver:test');
-const log  = require('debug')('ble-driver:log');
+const log = require('debug')('ble-driver:log');
 const error = require('debug')('ble-driver:error');
 const statusLog = require('debug')('ble-driver:status');
 
@@ -174,26 +174,15 @@ function determineSoftDeviceParameters(serialNumber) {
  * @private
  */
 function _filterAdapters(serialNumbers, options) {
-    // Use options provided to function primarily, from environment variables secondary
-    const filterOptions = { ...options };
-
-    if (filterOptions.family == null && process.env.PC_BLE_DRIVER_TEST_FAMILY) {
-        filterOptions.family = process.env.PC_BLE_DRIVER_TEST_FAMILY;
-    }
-
-    if (filterOptions.blacklist == null && process.env.PC_BLE_DRIVER_TEST_BLACKLIST) {
-        filterOptions.blacklist = process.env.PC_BLE_DRIVER_TEST_BLACKLIST.split(',');
-    }
-
     return serialNumbers.filter(sn => {
-        if (filterOptions.blacklist) {
-            if (filterOptions.blacklist.includes(sn)) {
+        if (options.blacklist) {
+            if (options.blacklist.includes(sn)) {
                 return false;
             }
         }
 
-        if (filterOptions.family) {
-            return determineSoftDeviceParameters(sn).family === filterOptions.family;
+        if (options.family) {
+            return determineSoftDeviceParameters(sn).family === options.family;
         }
 
         return true;
@@ -248,16 +237,14 @@ async function _grabAdapter(serialNumber, options) {
 
     const softDeviceParams = determineSoftDeviceParameters(selectedAdapter.serialNumber);
 
-    const skipSetupDevice = options && options.programDevice === false;
-
-    if (!skipSetupDevice) {
+    if (options.programDevice) {
         const deviceFirmware = FirmwareRegistry.getDeviceSetup();
 
         Object.keys(deviceFirmware).forEach(key => {
             if (key === 'jprog') {
                 Object.keys(deviceFirmware.jprog).forEach(family => {
                     // Replacing fwVersion validator to always return false, forcing programming of the device.
-                    deviceFirmware.jprog[family].fwVersion.validator = () => { false };
+                    deviceFirmware.jprog[family].fwVersion.validator = () => false;
                 });
             } else if (key === 'dfu') {
                 Object.keys(deviceFirmware.dfu).forEach(deviceType => {
@@ -357,6 +344,36 @@ function addAdapterListener(adapter, prefix) {
  */
 
 /**
+ * Merge options from environment variables and options provided by developer.
+ *
+ * Options provided by developer wins over options provided from environment variables
+ *
+ * @param {GrabAdapterOptions} [options] to use when grabbing the adapter.
+ * @returns {GrabAdapterOptions} New options object with information gathered from environment variables and options provided by developer.
+ */
+function mergeOptions(options) {
+    const newOptions = Object.assign({}, options);
+
+    if (!newOptions.logLevel) {
+        newOptions.logLevel = process.env.PC_BLE_DRIVER_TEST_LOGLEVEL || 'info';
+    }
+
+    if (!newOptions.programDevice) {
+        newOptions.programDevice = process.env.PC_BLE_DRIVER_TEST_SKIP_PROGRAMMING == null;
+    }
+
+    if (newOptions.family == null && process.env.PC_BLE_DRIVER_TEST_FAMILY) {
+        newOptions.family = process.env.PC_BLE_DRIVER_TEST_FAMILY;
+    }
+
+    if (newOptions.blacklist == null && process.env.PC_BLE_DRIVER_TEST_BLACKLIST) {
+        newOptions.blacklist = process.env.PC_BLE_DRIVER_TEST_BLACKLIST.split(',');
+    }
+
+    return newOptions;
+}
+
+/**
  * Grab an available adapter.
  *
  * @param {string} [requestedSerialNumber] Specific adapter to grab, if undefined, the function picks one that is not registered as grabbed from before
@@ -364,7 +381,9 @@ function addAdapterListener(adapter, prefix) {
  * @returns {Promise<Adapter>} An opened adapter ready to use
  */
 async function grabAdapter(requestedSerialNumber, options) {
-    const { port, serialNumber, apiVersion, baudRate } = await _grabAdapter(requestedSerialNumber, options);
+    const options_ = mergeOptions(options);
+
+    const { port, serialNumber, apiVersion, baudRate } = await _grabAdapter(requestedSerialNumber, options_);
     const adapter = adapterFactory.createAdapter(apiVersion, port, serialNumber);
     addAdapterListener(adapter);
 
@@ -373,20 +392,9 @@ async function grabAdapter(requestedSerialNumber, options) {
     // Update the grabbed adapter value to be an instance of Adapter and not Device from nrf-device-lister
     grabbedAdapters.set(serialNumber, adapter);
 
-    // Setup log level in pc-ble-driver based on function argument options or env variable
-    let logLevel;
-
-    if (options && options.logLevel) {
-        logLevel = options.logLevel;
-    } else if (process.env.PC_BLE_DRIVER_TEST_LOGLEVEL) {
-        logLevel = process.env.PC_BLE_DRIVER_TEST_LOGLEVEL;
-    } else {
-        logLevel = 'info';
-    }
-
     return new Promise((resolve, reject) => {
         debug(`Opening adapter ${serialNumber}.`);
-        adapter.open({ baudRate, logLevel }, err => {
+        adapter.open({ baudRate, logLevel: options_.logLevel }, err => {
             if (err) {
                 reject(new Error(`Error opening adapter ${serialNumber}: ${err}.`));
                 return;

--- a/test/simpleScan.test.js
+++ b/test/simpleScan.test.js
@@ -38,7 +38,7 @@
 
 const { grabAdapter, releaseAdapter, setupAdapter, outcome } = require('./setup');
 
-const debug = require('debug')('debug');
+const debug = require('debug')('ble-driver:test:simple-scan');
 
 const scanParameters = {
     active: true,
@@ -50,7 +50,7 @@ const scanParameters = {
 const CENTRAL_DEVICE_ADDRESS = 'FF:11:22:33:AA:CF';
 const CENTRAL_DEVICE_ADDRESS_TYPE = 'BLE_GAP_ADDR_TYPE_RANDOM_STATIC';
 
-const SCAN_DURATION_WAIT_TIME = 1500;
+const SCAN_DURATION_WAIT_TIME = 3000;
 
 describe('the API', async () => {
     let adapter;

--- a/test/simpleSecurity.test.js
+++ b/test/simpleSecurity.test.js
@@ -41,7 +41,7 @@ const { grabAdapter, releaseAdapter, setupAdapter, outcome } = require('./setup'
 const assert = require('assert');
 const crypto = require('crypto');
 
-const debug = require('debug')('debug');
+const debug = require('debug')('ble-driver:test:simple-security');
 
 const PERIPHERAL_DEVICE_ADDRESS = 'FF:11:22:33:AA:CE';
 const PERIPHERAL_DEVICE_ADDRESS_TYPE = 'BLE_GAP_ADDR_TYPE_RANDOM_STATIC';


### PR DESCRIPTION
This pull-request is mainly related to integration tests:
* Changed loggers to be more fine grained
* Added option to skip programming of devices
* Remove PC_ prefix in environment variable names
* Added README
* Tune timeout values related to receiving advertisement reports

In addition:
* Bumped version of nrf-device-setup to 0.2.5