### PR TITLE
Free function pointers preventing adapter addon from being destructed.

### DIFF
--- a/src/adapter.cpp
+++ b/src/adapter.cpp
@@ -241,6 +241,7 @@ void Adapter::cleanUpV8Resources()
         uv_close(handle, [](uv_handle_t *handle) {
             free(handle);
         });
+        delete this->statusCallback;
 
         asyncStatus = nullptr;
     }
@@ -270,6 +271,7 @@ void Adapter::cleanUpV8Resources()
         {
             free(handle);
         });
+        delete this->eventCallback;
 
         asyncEvent = nullptr;
     }
@@ -281,7 +283,8 @@ void Adapter::cleanUpV8Resources()
         {
             free(handle);
         });
-
+        delete this->logCallback;
+        
         asyncLog = nullptr;
     }
 

--- a/src/adapter.cpp
+++ b/src/adapter.cpp
@@ -119,7 +119,7 @@ extern "C" {
     }
 }
 
-void Adapter::initEventHandling(std::unique_ptr<Nan::Callback>& callback, uint32_t interval)
+void Adapter::initEventHandling(std::unique_ptr<Nan::Callback> &callback, uint32_t interval)
 {
     eventInterval = interval;
     asyncEvent = new uv_async_t();
@@ -186,7 +186,7 @@ extern "C" {
     }
 }
 
-void Adapter::initLogHandling(std::unique_ptr<Nan::Callback>& callback)
+void Adapter::initLogHandling(std::unique_ptr<Nan::Callback> &callback)
 {
     // Setup event related functionality
     asyncLog = new uv_async_t();
@@ -217,7 +217,7 @@ extern "C" {
     }
 }
 
-void Adapter::initStatusHandling(std::unique_ptr<Nan::Callback>& callback)
+void Adapter::initStatusHandling(std::unique_ptr<Nan::Callback> &callback)
 {
     // Setup event related functionality
     asyncStatus = new uv_async_t();

--- a/src/adapter.cpp
+++ b/src/adapter.cpp
@@ -119,13 +119,13 @@ extern "C" {
     }
 }
 
-void Adapter::initEventHandling(Nan::Callback *callback, uint32_t interval)
+void Adapter::initEventHandling(std::unique_ptr<Nan::Callback>& callback, uint32_t interval)
 {
     eventInterval = interval;
     asyncEvent = new uv_async_t();
 
     // Setup event related functionality
-    eventCallback = callback;
+    eventCallback = std::move(callback);
     asyncEvent->data = static_cast<void *>(this);
 
     if (uv_async_init(uv_default_loop(), asyncEvent, event_handler) != 0)
@@ -186,11 +186,11 @@ extern "C" {
     }
 }
 
-void Adapter::initLogHandling(Nan::Callback *callback)
+void Adapter::initLogHandling(std::unique_ptr<Nan::Callback>& callback)
 {
     // Setup event related functionality
     asyncLog = new uv_async_t();
-    logCallback = callback;
+    logCallback = std::move(callback);
     asyncLog->data = static_cast<void *>(this);
 
     if (uv_async_init(uv_default_loop(), asyncLog, log_handler) != 0)
@@ -217,11 +217,11 @@ extern "C" {
     }
 }
 
-void Adapter::initStatusHandling(Nan::Callback *callback)
+void Adapter::initStatusHandling(std::unique_ptr<Nan::Callback>& callback)
 {
     // Setup event related functionality
     asyncStatus = new uv_async_t();
-    statusCallback = callback;
+    statusCallback = std::move(callback);
     asyncStatus->data = static_cast<void *>(this);
 
     if (uv_async_init(uv_default_loop(), asyncStatus, status_handler) != 0)
@@ -241,7 +241,7 @@ void Adapter::cleanUpV8Resources()
         uv_close(handle, [](uv_handle_t *handle) {
             free(handle);
         });
-        delete this->statusCallback;
+        this->statusCallback.reset();
 
         asyncStatus = nullptr;
     }
@@ -271,7 +271,7 @@ void Adapter::cleanUpV8Resources()
         {
             free(handle);
         });
-        delete this->eventCallback;
+        this->eventCallback.reset();
 
         asyncEvent = nullptr;
     }
@@ -283,8 +283,8 @@ void Adapter::cleanUpV8Resources()
         {
             free(handle);
         });
-        delete this->logCallback;
-        
+        this->logCallback.reset();
+
         asyncLog = nullptr;
     }
 

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -93,18 +93,18 @@ public:
 
     adapter_t *getInternalAdapter() const;
 
-    void initEventHandling(std::unique_ptr<Nan::Callback>& callback, const uint32_t interval);
+    void initEventHandling(std::unique_ptr<Nan::Callback> &callback, const uint32_t interval);
     void appendEvent(ble_evt_t *event);
 
     void onRpcEvent(uv_async_t *handle);
     void eventIntervalCallback(uv_timer_t *handle);
 
-    void initLogHandling(std::unique_ptr<Nan::Callback>& callback);
+    void initLogHandling(std::unique_ptr<Nan::Callback> &callback);
     void appendLog(LogEntry *log);
 
     void onLogEvent(uv_async_t *handle);
 
-    void initStatusHandling(std::unique_ptr<Nan::Callback>& callback);
+    void initStatusHandling(std::unique_ptr<Nan::Callback> &callback);
     void appendStatus(StatusEntry *log);
 
     void onStatusEvent(uv_async_t *handle);

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -93,18 +93,18 @@ public:
 
     adapter_t *getInternalAdapter() const;
 
-    void initEventHandling(Nan::Callback *callback, const uint32_t interval);
+    void initEventHandling(std::unique_ptr<Nan::Callback>& callback, const uint32_t interval);
     void appendEvent(ble_evt_t *event);
 
     void onRpcEvent(uv_async_t *handle);
     void eventIntervalCallback(uv_timer_t *handle);
 
-    void initLogHandling(Nan::Callback *callback);
+    void initLogHandling(std::unique_ptr<Nan::Callback>& callback);
     void appendLog(LogEntry *log);
 
     void onLogEvent(uv_async_t *handle);
 
-    void initStatusHandling(Nan::Callback *callback);
+    void initStatusHandling(std::unique_ptr<Nan::Callback>& callback);
     void appendStatus(StatusEntry *log);
 
     void onStatusEvent(uv_async_t *handle);
@@ -227,9 +227,9 @@ private:
     LogQueue logQueue;
     StatusQueue statusQueue;
 
-    Nan::Callback *eventCallback;
-    Nan::Callback *logCallback;
-    Nan::Callback *statusCallback;
+    std::unique_ptr<Nan::Callback> eventCallback;
+    std::unique_ptr<Nan::Callback> logCallback;
+    std::unique_ptr<Nan::Callback> statusCallback;
 
     // Interval to use for sending BLE driver events to JavaScript. If 0 events will be sent as soon as they are received from the BLE driver.
     uint32_t eventInterval;

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -655,7 +655,7 @@ NAN_METHOD(Adapter::Open)
 
     try
     {
-        baton->log_callback = new Nan::Callback(ConversionUtility::getCallbackFunction(options, "logCallback"));
+        baton->log_callback = std::unique_ptr<Nan::Callback>(new Nan::Callback(ConversionUtility::getCallbackFunction(options, "logCallback")));
     }
     catch (std::string error)
     {
@@ -666,7 +666,7 @@ NAN_METHOD(Adapter::Open)
 
     try
     {
-        baton->event_callback = new Nan::Callback(ConversionUtility::getCallbackFunction(options, "eventCallback"));
+        baton->event_callback = std::unique_ptr<Nan::Callback>(new Nan::Callback(ConversionUtility::getCallbackFunction(options, "eventCallback")));
     }
     catch (std::string error)
     {
@@ -677,7 +677,7 @@ NAN_METHOD(Adapter::Open)
 
     try
     {
-        baton->status_callback = new Nan::Callback(ConversionUtility::getCallbackFunction(options, "statusCallback"));
+        baton->status_callback = std::unique_ptr<Nan::Callback>(new Nan::Callback(ConversionUtility::getCallbackFunction(options, "statusCallback")));
     }
     catch (std::string error)
     {

--- a/src/driver.h
+++ b/src/driver.h
@@ -236,9 +236,9 @@ public:
     BATON_CONSTRUCTOR(OpenBaton)
     //char path[PATH_STRING_SIZE];
     std::string path;
-    Nan::Callback *event_callback; // Callback that is called for every event that is received from the SoftDevice
-    Nan::Callback *log_callback;   // Callback that is called for every log entry that is received from the SoftDevice
-    Nan::Callback *status_callback;   // Callback that is called for every status occuring in the pc-ble-driver
+    std::unique_ptr<Nan::Callback> event_callback; // Callback that is called for every event that is received from the SoftDevice
+    std::unique_ptr<Nan::Callback> log_callback;   // Callback that is called for every log entry that is received from the SoftDevice
+    std::unique_ptr<Nan::Callback> status_callback;   // Callback that is called for every status occuring in the pc-ble-driver
 
     sd_rpc_log_severity_t log_level;
     sd_rpc_log_handler_t log_handler;


### PR DESCRIPTION
statusCallback, logCallback and eventCallback function pointers are allocated when an adapter is opened. They should be deallocated when the adapter is closed to prevent a memory leak. This also allows the garbage collector to call the adapter addon destructor.