### PR TITLE
Fixing some memory leaks in addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0",
     "gh-pages": "^1.0.0",
-    "jest": "^22.4.3",
+    "jest": "^23.5.0",
     "jest-bamboo-formatter": "1.0.1",
     "jest-serializer-path": "^0.1.14",
     "jscs": "^2.3.5",

--- a/src/adapter.cpp
+++ b/src/adapter.cpp
@@ -239,7 +239,7 @@ void Adapter::cleanUpV8Resources()
     {
         auto handle = reinterpret_cast<uv_handle_t *>(asyncStatus);
         uv_close(handle, [](uv_handle_t *handle) {
-            free(handle);
+            delete handle;
         });
         this->statusCallback.reset();
 
@@ -257,7 +257,7 @@ void Adapter::cleanUpV8Resources()
         auto handle = reinterpret_cast<uv_handle_t *>(eventIntervalTimer);
         uv_close(handle, [](uv_handle_t *handle)
         {
-            free(handle);
+            delete handle;
         });
 
         eventIntervalTimer = nullptr;
@@ -269,7 +269,7 @@ void Adapter::cleanUpV8Resources()
 
         uv_close(handle, [](uv_handle_t *handle)
         {
-            free(handle);
+            delete handle;
         });
         this->eventCallback.reset();
 
@@ -281,7 +281,7 @@ void Adapter::cleanUpV8Resources()
         auto logHandle = reinterpret_cast<uv_handle_t *>(asyncLog);
         uv_close(logHandle, [](uv_handle_t *handle)
         {
-            free(handle);
+            delete handle;
         });
         this->logCallback.reset();
 

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -40,6 +40,7 @@
 #include <nan.h>
 #include <chrono>
 #include <map>
+#include <memory>
 
 #include "sd_rpc.h"
 

--- a/src/common.h
+++ b/src/common.h
@@ -90,6 +90,8 @@ public:
     virtual NativeType *ToNative() { /*TODO: ASSERT*/ return new NativeType(); }
 
     operator NativeType*() { return ToNative(); }
+
+    /*TODO: Should be redesigned to not leak memory.*/
     operator NativeType() { return *(ToNative()); }
     operator v8::Handle<v8::Value>()
     {

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -584,7 +584,6 @@ void Adapter::AfterEnableBLE(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 3, argv);
-    delete baton->enable_params;
     delete baton;
 }
 
@@ -709,6 +708,11 @@ void Adapter::Open(uv_work_t *req)
     auto serialization = sd_rpc_transport_layer_create(h5, baton->response_timeout);
     auto adapter = sd_rpc_adapter_create(serialization);
 
+    // Free memory malloc'ed by the sd_rpc_create* functions
+    free(uart);
+    free(h5);
+    free(serialization);
+
     baton->adapter = adapter;
     baton->mainObject->adapter = adapter;
 
@@ -734,11 +738,6 @@ void Adapter::Open(uv_work_t *req)
 
         // Delete the adapter layer and all layers below
         sd_rpc_adapter_delete(adapter);
-
-        // Free memory malloc'ed by the sd_rpc_create* functions
-        free(uart);
-        free(h5);
-        free(serialization);
         free(adapter);
 
         return;
@@ -838,6 +837,10 @@ void Adapter::AfterClose(uv_work_t *req)
         else
         {
             argv[0] = Nan::Undefined();
+
+            sd_rpc_adapter_delete(baton->adapter);
+            free(baton->adapter);
+            baton->adapter = nullptr;
         }
 
         Nan::Call(*(baton->callback), 1, argv);
@@ -1072,7 +1075,6 @@ void Adapter::AfterGetVersion(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 2, argv);
-    delete baton->version;
     delete baton;
 }
 
@@ -1149,7 +1151,6 @@ void Adapter::AfterEncodeUUID(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 4, argv);
-    delete baton->uuid_le;
     delete baton;
 }
 
@@ -1215,8 +1216,6 @@ void Adapter::AfterDecodeUUID(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 2, argv);
-    delete baton->p_uuid;
-    delete baton->uuid_le;
     delete baton;
 }
 
@@ -1300,7 +1299,6 @@ void Adapter::AfterReplyUserMemory(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 1, argv);
-    delete baton->p_block;
     delete baton;
 }
 
@@ -1453,7 +1451,6 @@ void Adapter::AfterGetBleOption(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 2, argv);
-    delete baton->p_opt;
     delete baton;
 }
 

--- a/src/driver.h
+++ b/src/driver.h
@@ -38,6 +38,7 @@
 #define BLE_DRIVER_JS_DRIVER_H
 
 #include <string>
+#include <memory>
 
 #include <sd_rpc.h>
 #include "common.h"

--- a/src/driver.h
+++ b/src/driver.h
@@ -276,7 +276,8 @@ public:
 struct EnableBLEBaton : public Baton
 {
 public:
-    BATON_CONSTRUCTOR(EnableBLEBaton)
+    BATON_CONSTRUCTOR(EnableBLEBaton);
+    BATON_DESTRUCTOR(EnableBLEBaton) { delete enable_params; }
     ble_enable_params_t *enable_params;
     uint32_t app_ram_base;
 };
@@ -286,6 +287,7 @@ struct GetVersionBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GetVersionBaton);
+    BATON_DESTRUCTOR(GetVersionBaton) { delete version; }
     ble_version_t *version;
 
 };
@@ -294,6 +296,7 @@ class BleAddVendorSpcificUUIDBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(BleAddVendorSpcificUUIDBaton);
+    BATON_DESTRUCTOR(BleAddVendorSpcificUUIDBaton) { delete p_vs_uuid; }
     ble_uuid128_t *p_vs_uuid;
     uint8_t p_uuid_type;
 };
@@ -302,6 +305,11 @@ class BleUUIDEncodeBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(BleUUIDEncodeBaton);
+    BATON_DESTRUCTOR(BleUUIDEncodeBaton)
+    {
+        delete p_uuid;
+        delete uuid_le;
+    }
     ble_uuid_t *p_uuid;
     uint8_t uuid_le_len;
     uint8_t *uuid_le;
@@ -311,6 +319,11 @@ class BleUUIDDecodeBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(BleUUIDDecodeBaton);
+    BATON_DESTRUCTOR(BleUUIDDecodeBaton)
+    {
+        delete p_uuid;
+        delete uuid_le;
+    }
     uint8_t uuid_le_len;
     ble_uuid_t *p_uuid;
     uint8_t *uuid_le;
@@ -320,6 +333,11 @@ class BleUserMemReplyBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(BleUserMemReplyBaton);
+    BATON_DESTRUCTOR(BleUserMemReplyBaton)
+    {
+        free(p_block->p_mem);
+        delete p_block;
+    }
     uint16_t conn_handle;
     ble_user_mem_block_t *p_block;
 };
@@ -328,6 +346,7 @@ class BleOptionBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(BleOptionBaton);
+    BATON_DESTRUCTOR(BleOptionBaton) { delete p_opt; }
     uint32_t opt_id;
     ble_opt_t *p_opt;
 };

--- a/src/driver_gap.cpp
+++ b/src/driver_gap.cpp
@@ -473,6 +473,7 @@ ble_gap_irk_t *GapIrk::ToNative()
     {
         irk->irk[i] = p_irk[i];
     }
+    free(p_irk);
 
     return irk;
 }
@@ -685,6 +686,7 @@ ble_gap_enc_info_t *GapEncInfo::ToNative()
     {
         enc_info->ltk[i] = p_ltk[i];
     }
+    free(p_ltk);
 
     enc_info->auth = ConversionUtility::getNativeBool(jsobj, "auth");
     enc_info->ltk_len = ConversionUtility::getNativeUint8(jsobj, "ltk_len");
@@ -725,6 +727,7 @@ ble_gap_master_id_t *GapMasterId::ToNative()
     {
         master_id->rand[i] = p_rand[i];
     }
+    free(p_rand);
 
     return master_id;
 }
@@ -758,6 +761,7 @@ ble_gap_sign_info_t *GapSignInfo::ToNative()
     {
         sign_info->csrk[i] = p_csrk[i];
     }
+    free(p_csrk);
 
     return sign_info;
 }
@@ -791,6 +795,7 @@ ble_gap_lesc_p256_pk_t *GapLescP256Pk::ToNative()
     {
         lesc_p256->pk[i] = p_pk[i];
     }
+    free(p_pk);
 
     return lesc_p256;
 }
@@ -823,6 +828,7 @@ ble_gap_lesc_dhkey_t *GapLescDHKey::ToNative()
     {
         lesc_dhkey->key[i] = p_key[i];
     }
+    free(p_key);
 
     return lesc_dhkey;
 }
@@ -1918,7 +1924,6 @@ void Adapter::AfterGapSetDeviceName(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 1, argv);
-    free(baton->dev_name);
     delete baton;
 }
 
@@ -1985,7 +1990,6 @@ void Adapter::AfterGapGetDeviceName(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 2, argv);
-    free(baton->dev_name);
     delete baton;
 }
 
@@ -2653,7 +2657,6 @@ void Adapter::AfterGapGetConnectionSecurity(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 2, argv);
-    delete baton->conn_sec;
     delete baton;
 }
 
@@ -3235,7 +3238,6 @@ void Adapter::AfterGapSetPPCP(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 1, argv);
-    delete baton->p_conn_params;
     delete baton;
 }
 
@@ -3295,7 +3297,6 @@ void Adapter::AfterGapGetPPCP(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 2, argv);
-    delete baton->p_conn_params;
     delete baton;
 }
 
@@ -3461,7 +3462,7 @@ NAN_METHOD(Adapter::GapReplyAuthKey)
         {
             v8::Local<v8::String> message = ErrorMessage::getTypeErrorMessage(argumentcount, "ascii number");
             Nan::ThrowTypeError(message);
-            delete key;
+            free(key);
             return;
         }
     }
@@ -3539,7 +3540,7 @@ NAN_METHOD(Adapter::GapReplyDHKeyLESC)
     ble_gap_lesc_dhkey_t *dhkey = new ble_gap_lesc_dhkey_t();
     memcpy(dhkey->key, key, BLE_GAP_LESC_DHKEY_LEN);
     baton->dhkey = dhkey;
-    delete key;
+    free(key);
 
     uv_queue_work(uv_default_loop(), baton->req, GapReplyDHKeyLESC, reinterpret_cast<uv_after_work_cb>(AfterGapReplyDHKeyLESC));
 }
@@ -3569,7 +3570,6 @@ void Adapter::AfterGapReplyDHKeyLESC(uv_work_t *req)
     }
 
     Nan::Call(*(baton->callback), 1, argv);
-    delete baton->dhkey;
     delete baton;
 }
 #pragma endregion GapReplyDHKeyLESC
@@ -3674,6 +3674,7 @@ NAN_METHOD(Adapter::GapGetLESCOOBData)
     baton->conn_handle = conn_handle;
 
     memcpy(p_pk_own->pk, key, BLE_GAP_LESC_P256_PK_LEN);
+    free(key);
     baton->p_pk_own = p_pk_own;
     baton->p_oobd_own = new ble_gap_lesc_oob_data_t();
 
@@ -3708,8 +3709,6 @@ void Adapter::AfterGapGetLESCOOBData(uv_work_t *req)
 
     Nan::Call(*(baton->callback), 2, argv);
 
-    delete baton->p_pk_own;
-    delete baton->p_oobd_own;
     delete baton;
 }
 #pragma endregion GapGetLESCOOBData
@@ -3801,8 +3800,6 @@ void Adapter::AfterGapSetLESCOOBData(uv_work_t *req)
 
     Nan::Call(*(baton->callback), 1, argv);
 
-    delete baton->p_oobd_own;
-    delete baton->p_oobd_peer;
     delete baton;
 }
 #pragma endregion GapSetLESCOOBData

--- a/src/driver_gap.h
+++ b/src/driver_gap.h
@@ -485,6 +485,7 @@ struct GapAddressSetBaton : Baton
 {
 public:
     BATON_CONSTRUCTOR(GapAddressSetBaton);
+    BATON_DESTRUCTOR(GapAddressSetBaton) { delete address; }
     ble_gap_addr_t *address;
 #if NRF_SD_BLE_API_VERSION <= 2
     uint8_t addr_cycle_mode;
@@ -495,6 +496,7 @@ struct GapAddressGetBaton : Baton
 {
 public:
     BATON_CONSTRUCTOR(GapAddressGetBaton);
+    BATON_DESTRUCTOR(GapAddressGetBaton) { delete address; }
     ble_gap_addr_t *address;
 };
 
@@ -502,6 +504,7 @@ struct StartScanBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(StartScanBaton);
+    BATON_DESTRUCTOR(StartScanBaton) { delete scan_params; }
     ble_gap_scan_params_t *scan_params;
 };
 
@@ -522,6 +525,11 @@ struct GapSetDeviceNameBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapSetDeviceNameBaton);
+    BATON_DESTRUCTOR(GapSetDeviceNameBaton)
+    {
+        delete conn_sec_mode;
+        free(dev_name);
+    }
     ble_gap_conn_sec_mode_t *conn_sec_mode;
     uint8_t *dev_name;
     uint16_t length;
@@ -531,6 +539,7 @@ struct GapGetDeviceNameBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapGetDeviceNameBaton);
+    BATON_DESTRUCTOR(GapGetDeviceNameBaton) { free(dev_name); }
     uint8_t *dev_name;
     uint16_t length;
 };
@@ -539,6 +548,12 @@ struct GapConnectBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapConnectBaton);
+    BATON_DESTRUCTOR(GapConnectBaton)
+    {
+        delete address;
+        delete scan_params;
+        delete conn_params;
+    }
     ble_gap_addr_t *address;
     ble_gap_scan_params_t *scan_params;
     ble_gap_conn_params_t *conn_params;
@@ -595,6 +610,7 @@ struct GapStartAdvertisingBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapStartAdvertisingBaton);
+    BATON_DESTRUCTOR(GapStartAdvertisingBaton) { delete p_adv_params; }
     ble_gap_adv_params_t *p_adv_params;
 };
 
@@ -608,6 +624,11 @@ struct GapSecParamsReplyBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapSecParamsReplyBaton);
+    BATON_DESTRUCTOR(GapSecParamsReplyBaton)
+    {
+        delete sec_params;
+        delete sec_keyset;
+    }
     uint16_t conn_handle;
     uint8_t sec_status;
     ble_gap_sec_params_t *sec_params;
@@ -618,6 +639,7 @@ struct GapConnSecGetBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapConnSecGetBaton);
+    BATON_DESTRUCTOR(GapConnSecGetBaton) { delete conn_sec; }
     uint16_t conn_handle;
     ble_gap_conn_sec_t *conn_sec;
 };
@@ -626,6 +648,11 @@ struct GapEncryptBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapEncryptBaton);
+    BATON_DESTRUCTOR(GapEncryptBaton)
+    {
+        delete master_id;
+        delete enc_info;
+    }
     uint16_t conn_handle;
     ble_gap_master_id_t *master_id;
     ble_gap_enc_info_t *enc_info;
@@ -635,6 +662,12 @@ struct GapSecInfoReplyBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapSecInfoReplyBaton);
+    BATON_DESTRUCTOR(GapSecInfoReplyBaton)
+    {
+        delete enc_info;
+        delete id_info;
+        delete sign_info;
+    }
     uint16_t conn_handle;
     ble_gap_enc_info_t *enc_info;
     ble_gap_irk_t *id_info;
@@ -645,6 +678,7 @@ struct GapAuthenticateBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapAuthenticateBaton);
+    BATON_DESTRUCTOR(GapAuthenticateBaton) { delete p_sec_params; }
     uint16_t conn_handle;
     ble_gap_sec_params_t *p_sec_params;
 };
@@ -663,6 +697,7 @@ struct GapSetPPCPBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapSetPPCPBaton);
+    BATON_DESTRUCTOR(GapSetPPCPBaton) { delete p_conn_params; }
     ble_gap_conn_params_t *p_conn_params;
 };
 
@@ -670,6 +705,7 @@ struct GapGetPPCPBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapGetPPCPBaton);
+    BATON_DESTRUCTOR(GapGetPPCPBaton) { delete p_conn_params; }
     ble_gap_conn_params_t *p_conn_params;
 };
 
@@ -691,6 +727,7 @@ struct GapReplyAuthKeyBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapReplyAuthKeyBaton);
+    BATON_DESTRUCTOR(GapReplyAuthKeyBaton) { delete key; }
     uint16_t conn_handle;
     uint8_t key_type;
     uint8_t *key;
@@ -700,6 +737,7 @@ struct GapReplyDHKeyLESCBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapReplyDHKeyLESCBaton);
+    BATON_DESTRUCTOR(GapReplyDHKeyLESCBaton) { delete dhkey; }
     uint16_t conn_handle;
     ble_gap_lesc_dhkey_t *dhkey;
 };
@@ -716,6 +754,11 @@ struct GapGetLESCOOBDataBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapGetLESCOOBDataBaton);
+    BATON_DESTRUCTOR(GapGetLESCOOBDataBaton)
+    {
+        delete p_pk_own;
+        delete p_oobd_own;
+    }
     uint16_t conn_handle;
     ble_gap_lesc_p256_pk_t *p_pk_own;
     ble_gap_lesc_oob_data_t *p_oobd_own;
@@ -725,6 +768,11 @@ struct GapSetLESCOOBDataBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapSetLESCOOBDataBaton);
+    BATON_DESTRUCTOR(GapSetLESCOOBDataBaton)
+    {
+        delete p_oobd_own;
+        delete p_oobd_peer;
+    }
     uint16_t conn_handle;
     ble_gap_lesc_oob_data_t *p_oobd_own;
     ble_gap_lesc_oob_data_t *p_oobd_peer;
@@ -734,6 +782,12 @@ struct GapReplySecurityInfoBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapReplySecurityInfoBaton);
+    BATON_DESTRUCTOR(GapReplySecurityInfoBaton)
+    {
+        delete p_enc_info;
+        delete p_id_info;
+        delete p_sign_info;
+    }
     uint16_t conn_handle;
     ble_gap_enc_info_t *p_enc_info;
     ble_gap_irk_t *p_id_info;
@@ -744,6 +798,7 @@ struct GapGetConnectionSecurityBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GapGetConnectionSecurityBaton);
+    BATON_DESTRUCTOR(GapGetConnectionSecurityBaton) { delete p_conn_sec; }
     uint16_t conn_handle;
     ble_gap_conn_sec_t *p_conn_sec;
 };

--- a/src/driver_gattc.cpp
+++ b/src/driver_gattc.cpp
@@ -910,7 +910,6 @@ void Adapter::GattcReadCharacteristicValues(uv_work_t *req)
 {
     auto baton = static_cast<GattcReadCharacteristicValuesBaton *>(req->data);
     baton->result = sd_ble_gattc_char_values_read(baton->adapter, baton->conn_handle, baton->p_handles, baton->handle_count);
-    free(baton->p_handles);
 }
 
 // This runs in Main Thread

--- a/src/driver_gattc.h
+++ b/src/driver_gattc.h
@@ -258,6 +258,7 @@ struct GattcDiscoverPrimaryServicesBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattcDiscoverPrimaryServicesBaton);
+    BATON_DESTRUCTOR(GattcDiscoverPrimaryServicesBaton) { delete p_srvc_uuid; }
     uint16_t conn_handle;
     uint16_t start_handle;
     ble_uuid_t *p_srvc_uuid;
@@ -267,6 +268,7 @@ struct GattcDiscoverRelationshipBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattcDiscoverRelationshipBaton);
+    BATON_DESTRUCTOR(GattcDiscoverRelationshipBaton) { delete p_handle_range; }
     uint16_t conn_handle;
     ble_gattc_handle_range_t *p_handle_range;
 };
@@ -275,6 +277,7 @@ struct GattcDiscoverCharacteristicsBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattcDiscoverCharacteristicsBaton);
+    BATON_DESTRUCTOR(GattcDiscoverCharacteristicsBaton) { delete p_handle_range; }
     uint16_t conn_handle;
     ble_gattc_handle_range_t *p_handle_range;
 };
@@ -283,6 +286,7 @@ struct GattcDiscoverDescriptorsBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattcDiscoverDescriptorsBaton);
+    BATON_DESTRUCTOR(GattcDiscoverDescriptorsBaton) { delete p_handle_range; }
     uint16_t conn_handle;
     ble_gattc_handle_range_t *p_handle_range;
 };
@@ -291,6 +295,11 @@ struct GattcCharacteristicByUUIDReadBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattcCharacteristicByUUIDReadBaton);
+    BATON_DESTRUCTOR(GattcCharacteristicByUUIDReadBaton)
+    {
+        delete p_uuid;
+        delete p_handle_range;
+    }
     uint16_t conn_handle;
     ble_uuid_t *p_uuid;
     ble_gattc_handle_range_t *p_handle_range;
@@ -309,6 +318,7 @@ struct GattcReadCharacteristicValuesBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattcReadCharacteristicValuesBaton);
+    BATON_DESTRUCTOR(GattcReadCharacteristicValuesBaton) { free(p_handles); }
     uint16_t conn_handle;
     uint16_t *p_handles;
     uint16_t handle_count;
@@ -318,6 +328,11 @@ struct GattcWriteBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattcWriteBaton);
+    BATON_DESTRUCTOR(GattcWriteBaton)
+    {
+        free((char*)(p_write_params->p_value));
+        delete p_write_params;
+    }
     uint16_t conn_handle;
     ble_gattc_write_params_t *p_write_params;
 };

--- a/src/driver_gatts.cpp
+++ b/src/driver_gatts.cpp
@@ -546,7 +546,6 @@ void Adapter::AfterGattsAddCharacteristic(uv_work_t *req)
 
     Nan::Call(*(baton->callback), 2, argv);
 
-    delete baton->p_handles;
     delete baton;
 }
 
@@ -622,7 +621,6 @@ void Adapter::AfterGattsAddDescriptor(uv_work_t *req)
 
     Nan::Call(*(baton->callback), 2, argv);
 
-    delete baton->p_attr;
     delete baton;
 }
 
@@ -698,8 +696,6 @@ void Adapter::AfterGattsHVX(uv_work_t *req)
 
     Nan::Call(*(baton->callback), 1, argv);
 
-    delete baton->p_hvx_params->p_len;
-    delete baton->p_hvx_params;
     delete baton;
 }
 
@@ -790,7 +786,6 @@ void Adapter::AfterGattsSystemAttributeSet(uv_work_t *req)
 
     Nan::Call(*(baton->callback), 1, argv);
 
-    delete baton->p_sys_attr_data;
     delete baton;
 }
 
@@ -871,7 +866,6 @@ void Adapter::AfterGattsSetValue(uv_work_t *req)
 
     Nan::Call(*(baton->callback), 2, argv);
 
-    delete baton->p_value;
     delete baton;
 }
 
@@ -952,7 +946,6 @@ void Adapter::AfterGattsGetValue(uv_work_t *req)
 
     Nan::Call(*(baton->callback), 2, argv);
 
-    delete baton->p_value;
     delete baton;
 }
 
@@ -1026,7 +1019,6 @@ void Adapter::AfterGattsReplyReadWriteAuthorize(uv_work_t *req)
 
     Nan::Call(*(baton->callback), 1, argv);
 
-    delete baton->p_rw_authorize_reply_params;
     delete baton;
 }
 

--- a/src/driver_gatts.h
+++ b/src/driver_gatts.h
@@ -237,6 +237,7 @@ struct GattsAddServiceBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattsAddServiceBaton);
+    BATON_DESTRUCTOR(GattsAddServiceBaton) { delete p_uuid; }
     uint8_t type;
     ble_uuid_t *p_uuid;
     uint16_t p_handle;
@@ -246,6 +247,13 @@ struct GattsAddCharacteristicBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattsAddCharacteristicBaton);
+    BATON_DESTRUCTOR(GattsAddCharacteristicBaton)
+    {
+        delete p_char_md;
+        free((char*)(p_attr_char_value->p_value));
+        delete p_attr_char_value;
+        delete p_handles;
+    }
     uint16_t service_handle;
     ble_gatts_char_md_t *p_char_md;
     ble_gatts_attr_t *p_attr_char_value;
@@ -256,6 +264,11 @@ struct GattsAddDescriptorBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattsAddDescriptorBaton);
+    BATON_DESTRUCTOR(GattsAddDescriptorBaton)
+    {
+        free((char*)(p_attr->p_value));
+        delete p_attr;
+    }
     uint16_t char_handle;
     ble_gatts_attr_t *p_attr;
     uint16_t p_handle;
@@ -265,6 +278,12 @@ struct GattsHVXBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattsHVXBaton);
+    BATON_DESTRUCTOR(GattsHVXBaton)
+    {
+        free((char*)(p_hvx_params->p_len));
+        free((char*)(p_hvx_params->p_data));
+        delete p_hvx_params;
+    }
     uint16_t conn_handle;
     ble_gatts_hvx_params_t *p_hvx_params;
 };
@@ -273,6 +292,7 @@ struct GattsSystemAttributeSetBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattsSystemAttributeSetBaton);
+    BATON_DESTRUCTOR(GattsSystemAttributeSetBaton) { free(p_sys_attr_data); }
     uint16_t conn_handle;
     uint8_t *p_sys_attr_data;
     uint16_t len;
@@ -283,6 +303,11 @@ struct GattsSetValueBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattsSetValueBaton);
+    BATON_DESTRUCTOR(GattsSetValueBaton)
+    {
+        free((char*)(p_value->p_value));
+        delete p_value;
+    }
     uint16_t conn_handle;
     uint16_t handle;
     ble_gatts_value_t *p_value;
@@ -292,6 +317,11 @@ struct GattsGetValueBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattsGetValueBaton);
+    BATON_DESTRUCTOR(GattsGetValueBaton)
+    {
+        free((char*)(p_value->p_value));
+        delete p_value;
+    }
     uint16_t conn_handle;
     uint16_t handle;
     ble_gatts_value_t *p_value;
@@ -301,6 +331,7 @@ struct GattsReplyReadWriteAuthorizeBaton : public Baton
 {
 public:
     BATON_CONSTRUCTOR(GattsReplyReadWriteAuthorizeBaton);
+    BATON_DESTRUCTOR(GattsReplyReadWriteAuthorizeBaton) { delete p_rw_authorize_reply_params; }
     uint16_t conn_handle;
     ble_gatts_rw_authorize_reply_params_t *p_rw_authorize_reply_params;
 };

--- a/src/driver_uecc.cpp
+++ b/src/driver_uecc.cpp
@@ -138,6 +138,7 @@ NAN_METHOD(ECCP256ComputePublicKey)
     p_curve = uECC_secp256r1();
 
     reverse(&m_be_keys[0], (uint8_t *)p_le_sk, ECC_P256_SK_LEN);
+    free(p_le_sk);
 
     //int ret = uECC_compute_public_key(p_le_sk, (uint8_t *)p_le_pk, p_curve);
     int ret = uECC_compute_public_key((uint8_t *)&m_be_keys[0], (uint8_t *)&m_be_keys[ECC_P256_SK_LEN], p_curve);
@@ -185,6 +186,9 @@ NAN_METHOD(ECCP256ComputeSharedSecret)
     reverse(&m_be_keys[0], (uint8_t *)p_le_sk, ECC_P256_SK_LEN);
     reverse(&m_be_keys[ECC_P256_SK_LEN], (uint8_t *)&p_le_pk[0], ECC_P256_SK_LEN);
     reverse(&m_be_keys[ECC_P256_SK_LEN * 2], (uint8_t *)&p_le_pk[ECC_P256_SK_LEN], ECC_P256_SK_LEN);
+
+    free(p_le_sk);
+    free(p_le_pk);
 
     int ret = uECC_shared_secret((uint8_t *)&m_be_keys[ECC_P256_SK_LEN], (uint8_t *)&m_be_keys[0], p_le_ss, p_curve);
 


### PR DESCRIPTION
Added destructors to batons for memory management of the objects they have ownership of, and moved all delete statements to the destructors.
Also fixed some malloc->delete and new->free mismatches that have undefined behaviour.