### PR TITLE
Fix integration tests to better support DFU device

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nan": "2.3.3",
     "node-pre-gyp": "^0.6.39",
     "nrf-device-lister": "2.0.0",
-    "nrf-device-setup": "0.2.5",
+    "nrf-device-setup": "0.2.9",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/test/openClose.test.js
+++ b/test/openClose.test.js
@@ -49,7 +49,7 @@ const SCAN_DURATION = 2000;
 const SCAN_DURATION_WAIT_TIME = 3000;
 const EXPECTED_NUMBER_OF_SCAN_REPORTS_PR_ITERATION = 2;
 
-const GENERIC_WAIT_PR_ITERATION = 1000;
+const GENERIC_WAIT_PR_ITERATION = 15000;
 
 // Adjust the jest timeout based on the number of iterations required
 const JEST_TIMEOUT = NUMBER_OF_ITERATIONS *

--- a/test/setup.js
+++ b/test/setup.js
@@ -57,16 +57,14 @@ const DeviceLister = require('nrf-device-lister');
 const { setupDevice } = require('nrf-device-setup');
 const { FirmwareRegistry } = require('../index');
 
-const traits = {
+const deviceLister = new DeviceLister({
     usb: false,
     nordicUsb: true,
     seggerUsb: false,
     serialport: true,
     nordicDfu: true,
     jlink: true,
-};
-
-const deviceLister = new DeviceLister(traits);
+});
 const grabbedAdapters = new Map();
 
 deviceLister.on('error', err => {
@@ -99,8 +97,13 @@ function getAdapters() {
 
             // Only pick adapters we are able to program
             adapters.forEach((adapter, serialNumber) => {
-                const add = adapter.traits
-                    && (adapter.traits.includes('jlink') || adapter.traits.includes('nordicDfu'));
+                const { traits, serialport } = adapter;
+                const add = traits
+                    && (traits.includes('jlink') || traits.includes('nordicDfu')
+                        || (traits.includes('serialport')
+                            && serialport.vendorId === '1915'
+                            && serialport.productId.toUpperCase() === '521F')
+                    );
 
                 if (add) {
                     result.set(serialNumber, adapter);


### PR DESCRIPTION
For more stable DFU procedure nrf-device-setup 0.2.9 is needed.
Also changed device setup configuration to allow opening a dongle in bootloader mode.

Unfortunately due to Windows... Jest timeout needs to be much much more to allow a DFU'd device to attach. It's not even sure if 15s is enough, but at least in few test rounds of 10 iteration it proved to be acceptable.