### PR TITLE
Remove PR #184 due to failed integration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,11 +64,8 @@ foreach(SD_API_VER ${SD_API_VERS})
 	set_target_properties(${CURRENT_TARGET} PROPERTIES COMPILE_OPTIONS -DNRF_SD_BLE_API_VERSION=${_SD_API_VER_NUM})
 
     target_include_directories(${CURRENT_TARGET} PRIVATE ${PC_BLE_DRIVER_${SD_API_VER}_PUBLIC_INCLUDE_DIRS})
-
+	
     if(WIN32)
-        # suppress C4251 v8/msvc related warning, for more info: https://github.com/nodejs/node/pull/15570
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251")
-
         target_include_directories(${CURRENT_TARGET} PRIVATE "${CMAKE_JS_INC}/win")
         set_target_properties(${CURRENT_TARGET} PROPERTIES COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
     elseif(APPLE)

--- a/build.js
+++ b/build.js
@@ -36,11 +36,10 @@
 
 'use strict';
 
-const cmakeJS = require('cmake-js');
-const os = require('os');
-const fs = require('fs');
-
 function getBuildSystem(debug) {
+    const cmakeJS = require('cmake-js');
+    const os = require('os');
+
     const defaultRuntime = 'node';
     const defaultRuntimeVersion = process.version.substr(1);
     const defaultWinArch = os.arch();
@@ -62,7 +61,7 @@ function getBuildSystem(debug) {
         buildSystem.options.runtimeVersion = defaultRuntimeVersion;
     }
 
-    if (buildSystem.options.arch === undefined && process.platform === 'win32') {
+    if (buildSystem.options.arch === undefined && process.platform == 'win32') {
         buildSystem.options.arch = defaultWinArch;
     }
 
@@ -72,7 +71,8 @@ function getBuildSystem(debug) {
 let times = 0;
 
 function begin(args) {
-    // Sanity check for the platform-specific binary driver files
+	// Sanity check for the platform-specific binary driver files
+    const fs = require('fs');
     fs.readdir('./pc-ble-driver', (err, files) => {
         if (err) {
             console.error('ERROR: Could not read the \'pc-ble-driver\' subrepo, please check manually.');
@@ -84,20 +84,19 @@ function begin(args) {
     });
 
     let debug = false;
-    let build = 'rebuild';
 
-    for (let i = 0; i < args.length; i += 1) {
+    const length = args.length >>> 0;
+
+    for (let i = 0; i < length; i++) {
         if (args[i] === '--debug') debug = true;
-        if (args[i] === '--no-rebuild') build = 'build';
     }
 
     let buildSystem;
     try {
         buildSystem = getBuildSystem(debug);
     } catch (e) {
-        if (e.code === 'MODULE_NOT_FOUND') {
-            times += 1;
-            if (times === 5) {
+        if (e.code == 'MODULE_NOT_FOUND') {
+            if (times++ == 5) {
                 throw e;
             } else {
                 setTimeout(begin, 2000);
@@ -107,7 +106,7 @@ function begin(args) {
         }
     }
 
-    buildSystem[build]().catch(() => {
+    buildSystem.rebuild().catch(e => {
         process.exit(1);
     });
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cmake-js": "1.1.0",
     "crc": "^3.4.0",
     "jszip": "^3.1.2",
-    "nan": "2.10.0",
+    "nan": "2.3.3",
     "node-pre-gyp": "^0.6.39",
     "nrf-device-lister": "2.0.0",
     "nrf-device-setup": "0.3.0",

--- a/src/adapter.cpp
+++ b/src/adapter.cpp
@@ -426,7 +426,7 @@ NAN_METHOD(Adapter::New)
     else
     {
         v8::Local<v8::Function> cons = Nan::New(constructor);
-        info.GetReturnValue().Set(Nan::NewInstance(cons).ToLocalChecked());
+        info.GetReturnValue().Set(cons->NewInstance());
     }
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -211,7 +211,7 @@ public:
             throw std::string("number");
         }
 
-        return static_cast<NativeType>(js->Uint32Value());
+        return static_cast<NativeType>(js->ToUint32()->Uint32Value());
     }
 
     static NativeType getNativeSigned(v8::Local<v8::Value> js)
@@ -221,7 +221,7 @@ public:
             throw std::string("number");
         }
 
-        return static_cast<NativeType>(js->Int32Value());
+        return static_cast<NativeType>(js->ToInt32()->Int32Value());
     }
 
     static NativeType getNativeFloat(v8::Local<v8::Value> js)
@@ -231,7 +231,7 @@ public:
             throw std::string("number");
         }
 
-        return static_cast<NativeType>(js->NumberValue());
+        return static_cast<NativeType>(js->ToNumber()->NumberValue());
     }
 
     static NativeType getNativeBool(v8::Local<v8::Value> js)

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -154,7 +154,7 @@ void Adapter::onLogEvent(uv_async_t *handle)
             v8::Local<v8::Value> argv[2];
             argv[0] = ConversionUtility::toJsNumber(static_cast<int>(logEntry->severity));
             argv[1] = ConversionUtility::toJsString(logEntry->message);
-            Nan::Call(*logCallback, 2, argv);
+            logCallback->Call(2, argv);
         }
         else
         {
@@ -180,7 +180,7 @@ void Adapter::dispatchEvents()
         // Adapter::cleanUpV8Resources() is called from both Adapter::AfterClose and Adapter::AfterConnReset
         //
         // If Adapter::eventInterval is 0, this method, Adapter::dispatchEvents, will be called directly without being
-        // invoked from eventIntervalTimer.
+        // invoked from eventIntervalTimer. 
         //
         // When Adapter::AfterClose is invoked, parts of Adapter::cleanUpV8Resources() is ran before the
         // the following call graph is complete:
@@ -189,8 +189,8 @@ void Adapter::dispatchEvents()
         //
         // The above call graph is ran in thread SerializationTransport::eventThread when Adapter::eventInterval == 0.
         //
-        // If eventInterval != 0 the event is popped out of the Adapter::eventQueue queue by
-        // Adapter::eventIntervalTimer, in a libuv thread-pool thread. Adapter::eventIntervalTimer is stopped in
+        // If eventInterval != 0 the event is popped out of the Adapter::eventQueue queue by 
+        // Adapter::eventIntervalTimer, in a libuv thread-pool thread. Adapter::eventIntervalTimer is stopped in 
         // Adapter::cleanUpV8Resources().
         //
         // A quick fix to circumvent this race condition is to ignore the event when Adapter::asyncEvent is nullptr.
@@ -386,7 +386,7 @@ void Adapter::onRpcEvent(uv_async_t *handle)
 
     if (eventCallback != nullptr)
     {
-        Nan::Call(*eventCallback, 1, callback_value);
+        eventCallback->Call(1, callback_value);
     }
     else
     {
@@ -442,7 +442,7 @@ void Adapter::onStatusEvent(uv_async_t *handle)
         {
             v8::Local<v8::Value> argv[1];
             argv[0] = StatusMessage::getStatus(statusEntry->id, statusEntry->message, statusEntry->timestamp);
-            Nan::Call(*statusCallback, 1, argv);
+            statusCallback->Call(1, argv);
         }
 
         // Free memory for current entry, we remove the element from the deque when the iteration is done
@@ -583,7 +583,7 @@ void Adapter::AfterEnableBLE(uv_work_t *req)
         argv[2] = ConversionUtility::toJsNumber(baton->app_ram_base);
     }
 
-    Nan::Call(*(baton->callback), 3, argv);
+    baton->callback->Call(3, argv);
     delete baton;
 }
 
@@ -785,7 +785,7 @@ void Adapter::AfterOpen(uv_work_t *req)
     }
 
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
 
     delete baton;
 }
@@ -843,7 +843,7 @@ void Adapter::AfterClose(uv_work_t *req)
             baton->adapter = nullptr;
         }
 
-        Nan::Call(*(baton->callback), 1, argv);
+        baton->callback->Call(1, argv);
     }
 
     delete baton;
@@ -898,7 +898,7 @@ void Adapter::AfterConnReset(uv_work_t *req)
             argv[0] = Nan::Undefined();
         }
 
-        Nan::Call(*(baton->callback), 1, argv);
+        baton->callback->Call(1, argv);
     }
 
     delete baton;
@@ -958,7 +958,7 @@ void Adapter::AfterAddVendorSpecificUUID(uv_work_t *req)
         argv[1] = ConversionUtility::toJsNumber(baton->p_uuid_type);
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 
@@ -1074,7 +1074,7 @@ void Adapter::AfterGetVersion(uv_work_t *req)
         argv[1] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 
@@ -1150,7 +1150,7 @@ void Adapter::AfterEncodeUUID(uv_work_t *req)
         argv[3] = ConversionUtility::encodeHex(reinterpret_cast<char *>(baton->uuid_le), baton->uuid_le_len);
     }
 
-    Nan::Call(*(baton->callback), 4, argv);
+    baton->callback->Call(4, argv);
     delete baton;
 }
 
@@ -1215,7 +1215,7 @@ void Adapter::AfterDecodeUUID(uv_work_t *req)
         argv[1] = BleUUID(baton->p_uuid);
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 
@@ -1298,7 +1298,7 @@ void Adapter::AfterReplyUserMemory(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -1373,7 +1373,7 @@ void Adapter::AfterSetBleOption(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -1450,7 +1450,7 @@ void Adapter::AfterGetBleOption(uv_work_t *req)
         argv[1] = optionValue;
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 

--- a/src/driver_gap.cpp
+++ b/src/driver_gap.cpp
@@ -1567,7 +1567,7 @@ void Adapter::AfterGapSetAddress(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
 
     delete baton;
 }
@@ -1635,7 +1635,7 @@ void Adapter::AfterGapGetAddress(uv_work_t *req)
         argv[1] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 
@@ -1713,7 +1713,7 @@ void Adapter::AfterGapUpdateConnectionParameters(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -1779,7 +1779,7 @@ void Adapter::AfterGapDisconnect(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -1842,7 +1842,7 @@ void Adapter::AfterGapSetTXPower(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -1923,7 +1923,7 @@ void Adapter::AfterGapSetDeviceName(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -1989,7 +1989,7 @@ void Adapter::AfterGapGetDeviceName(uv_work_t *req)
         argv[1] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 
@@ -2060,7 +2060,7 @@ void Adapter::AfterGapStartRSSI(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -2121,7 +2121,7 @@ void Adapter::AfterGapStopRSSI(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -2184,7 +2184,7 @@ void Adapter::AfterGapStartScan(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -2240,7 +2240,7 @@ void Adapter::AfterGapStopScan(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -2342,7 +2342,7 @@ void Adapter::AfterGapConnect(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -2398,7 +2398,7 @@ void Adapter::AfterGapCancelConnect(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -2465,7 +2465,7 @@ void Adapter::AfterGapGetRSSI(uv_work_t *req)
         argv[1] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 
@@ -2536,7 +2536,7 @@ void Adapter::AfterGapStartAdvertising(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -2592,7 +2592,7 @@ void Adapter::AfterGapStopAdvertising(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -2656,7 +2656,7 @@ void Adapter::AfterGapGetConnectionSecurity(uv_work_t *req)
         argv[1] = GapConnSec(baton->conn_sec).ToJs();
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 
@@ -2745,7 +2745,7 @@ void Adapter::AfterGapEncrypt(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 #pragma endregion GapEncrypt
@@ -2894,7 +2894,7 @@ void Adapter::AfterGapReplySecurityParameters(uv_work_t *req)
         }
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 
@@ -2998,7 +2998,7 @@ void Adapter::AfterGapReplySecurityInfo(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -3074,7 +3074,7 @@ void Adapter::AfterGapAuthenticate(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -3166,7 +3166,7 @@ void Adapter::AfterGapSetAdvertisingData(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -3237,7 +3237,7 @@ void Adapter::AfterGapSetPPCP(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -3296,7 +3296,7 @@ void Adapter::AfterGapGetPPCP(uv_work_t *req)
         argv[1] = GapConnParams(baton->p_conn_params);
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 
@@ -3357,7 +3357,7 @@ void Adapter::AfterGapSetAppearance(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 #pragma endregion GapSetAppearance
@@ -3413,7 +3413,7 @@ void Adapter::AfterGapGetAppearance(uv_work_t *req)
         argv[1] = ConversionUtility::toJsNumber(baton->appearance);
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 #pragma endregion GapGetAppearance
@@ -3500,7 +3500,7 @@ void Adapter::AfterGapReplyAuthKey(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 #pragma endregion GapReplyAuthKey
@@ -3569,7 +3569,7 @@ void Adapter::AfterGapReplyDHKeyLESC(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 #pragma endregion GapReplyDHKeyLESC
@@ -3634,7 +3634,7 @@ void Adapter::AfterGapNotifyKeypress(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
 
     delete baton;
 }
@@ -3707,7 +3707,7 @@ void Adapter::AfterGapGetLESCOOBData(uv_work_t *req)
         argv[1] = GapLescOobData(baton->p_oobd_own);
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
 
     delete baton;
 }
@@ -3798,7 +3798,7 @@ void Adapter::AfterGapSetLESCOOBData(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
 
     delete baton;
 }

--- a/src/driver_gattc.cpp
+++ b/src/driver_gattc.cpp
@@ -470,7 +470,7 @@ void Adapter::AfterGattcDiscoverPrimaryServices(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
 
     delete baton;
 }
@@ -544,7 +544,7 @@ void Adapter::AfterGattcDiscoverRelationship(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -617,7 +617,7 @@ void Adapter::AfterGattcDiscoverCharacteristics(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -690,7 +690,7 @@ void Adapter::AfterGattcDiscoverDescriptors(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -778,7 +778,7 @@ void Adapter::AfterGattcReadCharacteristicValueByUUID(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -846,7 +846,7 @@ void Adapter::AfterGattcRead(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -929,7 +929,7 @@ void Adapter::AfterGattcReadCharacteristicValues(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -1002,7 +1002,7 @@ void Adapter::AfterGattcWrite(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -1064,7 +1064,7 @@ void Adapter::AfterGattcConfirmHandleValue(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 
@@ -1127,7 +1127,7 @@ void Adapter::AfterGattcExchangeMtuRequest(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 #endif

--- a/src/driver_gatts.cpp
+++ b/src/driver_gatts.cpp
@@ -455,7 +455,7 @@ void Adapter::AfterGattsAddService(uv_work_t *req)
         argv[1] = ConversionUtility::toJsNumber(baton->p_handle);
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
     delete baton;
 }
 
@@ -544,7 +544,7 @@ void Adapter::AfterGattsAddCharacteristic(uv_work_t *req)
         argv[1] = GattsCharacteristicDefinitionHandles(baton->p_handles).ToJs();
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
 
     delete baton;
 }
@@ -619,7 +619,7 @@ void Adapter::AfterGattsAddDescriptor(uv_work_t *req)
         argv[1] = ConversionUtility::toJsNumber(baton->p_handle);
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
 
     delete baton;
 }
@@ -694,7 +694,7 @@ void Adapter::AfterGattsHVX(uv_work_t *req)
         argv[1] = ConversionUtility::toJsNumber(*baton->p_hvx_params->p_len);
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
 
     delete baton;
 }
@@ -784,7 +784,7 @@ void Adapter::AfterGattsSystemAttributeSet(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
 
     delete baton;
 }
@@ -864,7 +864,7 @@ void Adapter::AfterGattsSetValue(uv_work_t *req)
         argv[1] = GattsValue(baton->p_value);
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
 
     delete baton;
 }
@@ -944,7 +944,7 @@ void Adapter::AfterGattsGetValue(uv_work_t *req)
         argv[1] = GattsValue(baton->p_value);
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
 
     delete baton;
 }
@@ -1017,7 +1017,7 @@ void Adapter::AfterGattsReplyReadWriteAuthorize(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
 
     delete baton;
 }
@@ -1081,7 +1081,7 @@ void Adapter::AfterGattsExchangeMtuReply(uv_work_t *req)
         argv[0] = Nan::Undefined();
     }
 
-    Nan::Call(*(baton->callback), 1, argv);
+    baton->callback->Call(1, argv);
     delete baton;
 }
 #endif

--- a/src/serialadapter.cpp
+++ b/src/serialadapter.cpp
@@ -30,14 +30,14 @@
 #include "serialadapter.h"
 #include "serial_port_enum.h"
 
-NAN_METHOD(GetAdapterList)
+NAN_METHOD(GetAdapterList) 
 {
     if(!info[0]->IsFunction())
     {
         Nan::ThrowTypeError("First argument must be a function");
         return;
     }
-
+  
     v8::Local<v8::Function> callback = info[0].As<v8::Function>();
     auto baton = new AdapterListBaton(callback);
     strcpy(baton->errorString, "");
@@ -52,24 +52,24 @@ void GetAdapterList(uv_work_t *req)
     EnumSerialPorts(baton->results);
 }
 
-void AfterGetAdapterList(uv_work_t* req)
+void AfterGetAdapterList(uv_work_t* req) 
 {
     Nan::HandleScope scope;
     auto baton = static_cast<AdapterListBaton*>(req->data);
 
     v8::Local<v8::Value> argv[2];
-
+  
     if(baton->errorString[0])
     {
         argv[0] = v8::Exception::Error(Nan::New(baton->errorString).ToLocalChecked());
         argv[1] = Nan::Undefined();
-    }
-    else
+    } 
+    else 
     {
         v8::Local<v8::Array> results = Nan::New<v8::Array>();
         auto i = 0;
 
-        for(auto adapterItem : baton->results)
+        for(auto adapterItem : baton->results) 
         {
             v8::Local<v8::Object> item = Nan::New<v8::Object>();
             Utility::Set(item, "comName", adapterItem->comName);
@@ -86,9 +86,9 @@ void AfterGetAdapterList(uv_work_t* req)
         argv[1] = results;
     }
 
-    Nan::Call(*(baton->callback), 2, argv);
+    baton->callback->Call(2, argv);
 
-    for(auto it = baton->results.begin(); it != baton->results.end(); ++it)
+    for(auto it = baton->results.begin(); it != baton->results.end(); ++it) 
     {
        delete *it;
     }


### PR DESCRIPTION
Two integration tests in simpleSecurity.test.js fails
using the code in PR #184.

Since we are in a hurry to release a new version of
pc-nrfconnect-core, we do not have time
to investigate the root cause right now.

We will investigate #184 and apply the changes
after the release of pc-nrfconnect-core.