### PR TITLE
Pin node-pre-gyp-github to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "keypress": "0.2.1",
     "minami": "^1.2.3",
     "mocha": "^2.3.3",
-    "node-pre-gyp-github": "^1.3.1",
+    "node-pre-gyp-github": "1.3.1",
     "proxyquire": "^1.7.3",
     "sinon": "^1.17.1",
     "yargs": "^3.29.0"


### PR DESCRIPTION
This PR is due to fixing failure when publishing to GitHub.
This branch has been successfully built on build server.