### PR TITLE
Fix race condition in disconnect function

### DIFF
--- a/api/adapter.js
+++ b/api/adapter.js
@@ -2522,16 +2522,19 @@ class Adapter extends EventEmitter {
         }
 
         const hciStatusCode = this._bleDriver.BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION;
+        this._gapOperationsMap[deviceInstanceId] = {
+            callback: callback,
+        };
+        
         this._adapter.gapDisconnect(device.connectionHandle, hciStatusCode, err => {
             if (err) {
                 const errorObject = _makeError('Failed to disconnect', err);
+                delete this._gapOperationsMap[deviceInstanceId];
                 this.emit('error', errorObject);
                 if (callback) { callback(errorObject); }
             } else {
                 // Expect a disconnect event down the road
-                this._gapOperationsMap[deviceInstanceId] = {
-                    callback: callback,
-                };
+                
             }
         });
     }


### PR DESCRIPTION
Sometimes the _adapter.gapDisconnect function may lead to a disconnect event coming in before the callback is called. This lead to race condition because the gapOperationsMap needs to be set before the event is processed. Assigning to the gapOperationMap before calling gapDisconnect should eliminate the race condition.
Resolves #160 . Regards to @Kaaml.