### PR TITLE
Use semicolons where necessary in typescript types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -83,16 +83,16 @@ export declare interface AuthParameters {
 }
 
 export declare interface AuthStatus {
-  auth_status: number,
-  auth_status_name: string,
-  error_src: number,
-  error_src_name: string,
-  bonded: boolean,
-  sm1_levels: number,
-  sm2_levels: number,
-  kdist_own: any, // FIXME:
-  kdist_peer: any, // FIXME:
-  keyset: any, // FIXME:
+  auth_status: number;
+  auth_status_name: string;
+  error_src: number;
+  error_src_name: string;
+  bonded: boolean;
+  sm1_levels: number;
+  sm2_levels: number;
+  kdist_own: any; // FIXME:
+  kdist_peer: any; // FIXME:
+  keyset: any; // FIXME:
 }
 
 export declare interface ConnectionOptions {
@@ -159,7 +159,7 @@ export declare interface CharacteristicProperties {
   write: boolean;
   notify: boolean;
   indicate: boolean;
-  auth_signed_wr: boolean
+  auth_signed_wr: boolean;
 }
 
 export declare interface CharacteristicExtProperties extends CharacteristicProperties {


### PR DESCRIPTION
A semicolon was missing in one place, and commas were used in others.