### PR TITLE
Fix failing GATT write preventing new GATT operation

### DIFF
--- a/api/adapter.js
+++ b/api/adapter.js
@@ -3624,6 +3624,7 @@ class Adapter extends EventEmitter {
 
         if (value.length > this._maxShortWritePayloadSize(device.instanceId)) {
             if (!ack) {
+                delete this._gattOperationsMap[device.instanceId];
                 throw new Error('Long writes do not support BLE_GATT_OP_WRITE_CMD');
             }
 

--- a/api/adapter.js
+++ b/api/adapter.js
@@ -3756,6 +3756,7 @@ class Adapter extends EventEmitter {
 
         if (value.length > this._maxShortWritePayloadSize(device.instanceId)) {
             if (!ack) {
+                delete this._gattOperationsMap[device.instanceId];
                 throw new Error('Long writes do not support BLE_GATT_OP_WRITE_CMD');
             }
 


### PR DESCRIPTION
When GATT write operation isn't performed the operation was still registered which prevented any further GATT operation on the device. This has been fixed.