### PR TITLE
Don't register vendor specific UUIDs on attribute read

### DIFF
--- a/test/tooManyVsCharacteristicUuids.test.js
+++ b/test/tooManyVsCharacteristicUuids.test.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2010 - 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2010 - 2019, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -49,26 +49,26 @@ const PERIPHERAL_DEVICE_ADDRESS_TYPE = 'BLE_GAP_ADDR_TYPE_RANDOM_STATIC';
 const CENTRAL_DEVICE_ADDRESS = 'FF:11:22:33:AA:CF';
 const CENTRAL_DEVICE_ADDRESS_TYPE = 'BLE_GAP_ADDR_TYPE_RANDOM_STATIC';
 
-async function onConnected(adapter, peerDevice) {
-    const services = await new Promise(resolve => {
-        adapter.getServices(peerDevice.instanceId, (getServicesErr, readServices) => {
-            expect(getServicesErr).toBeUndefined();
-            resolve(readServices);
-        });
-    });
-
-    const serviceId = services[2].instanceId;
-
-    await new Promise(resolve => {
-        adapter.getCharacteristics(serviceId, getCharacteristicsErr => {
-            expect(getCharacteristicsErr).toBeDefined();
-            expect(getCharacteristicsErr).toBe('Failed to add characteristic uuid to driver');
-            resolve(getCharacteristicsErr);
-        });
+function callbackPromise(promiseBody) {
+    return new Promise((resolve, reject) => {
+        function callbackFactory() {
+            const trace = {};
+            Error.captureStackTrace(trace, callbackFactory);
+            function callback(err, val) {
+                if (err) {
+                    let e = Error(err);
+                    Error.captureStackTrace(e, callback);
+                    e = e.stack.concat(trace.stack);
+                    reject(e);
+                } else resolve(val);
+            }
+            return callback;
+        }
+        promiseBody(callbackFactory);
     });
 }
 
-describe('the API', async () => {
+describe('During attribute discovery, the API', async () => {
     let centralAdapter;
     let peripheralAdapter;
 
@@ -90,27 +90,32 @@ describe('the API', async () => {
             releaseAdapter(peripheralAdapter.state.serialNumber)]);
     });
 
-    it('adding too many vendor specific characteristic uuids to driver will return an error', async () => {
+    it('allows for many vendor specific UUIDs', async () => {
         expect(centralAdapter).toBeDefined();
         expect(peripheralAdapter).toBeDefined();
 
-        await common.addRandomServicesAndCharacteristicsToAdapter(serviceFactory, peripheralAdapter, 1, 8);
-        await common.addRandomServicesAndCharacteristicsToAdapter(serviceFactory, centralAdapter, 1, 8);
+        await common.addRandomServicesAndCharacteristicsToAdapter(serviceFactory, peripheralAdapter, 8, 0);
+        await common.addRandomServicesAndCharacteristicsToAdapter(serviceFactory, centralAdapter, 8, 0);
 
-        const deviceConnectedCentral = new Promise((resolve, reject) => {
-            centralAdapter.once('deviceConnected', peripheralDevice => {
-                onConnected(centralAdapter, peripheralDevice).then(() => {
-                    resolve({
-                        address: peripheralDevice.address,
-                        type: peripheralDevice.addressType,
-                        instanceId: peripheralDevice.instanceId,
-                    });
-                }).catch(reject);
-            });
+        const connectionPromise = new Promise((resolve, reject) => {
+            centralAdapter.once('deviceConnected', resolve);
+            centralAdapter.once('error', reject);
         });
 
         await common.startAdvertising(peripheralAdapter);
         await common.connect(centralAdapter, { address: PERIPHERAL_DEVICE_ADDRESS, type: PERIPHERAL_DEVICE_ADDRESS_TYPE });
-        await outcome([deviceConnectedCentral]);
+
+        const connection = await connectionPromise;
+        const services = await callbackPromise(callback => {
+            centralAdapter.getServices(connection.instanceId, callback());
+        });
+
+        const service = services[2];
+
+        const characteristicsPromise = callbackPromise(callback => {
+            centralAdapter.getCharacteristics(service.instanceId, callback());
+        });
+
+        await outcome([characteristicsPromise]);
     });
 });


### PR DESCRIPTION
Currently, we register any 128 UUID bases unknown to the soft device during a read operation. This was likely a step in an attempt at optimizing the attribute discovery process, but is ineffective in it self since the discovery process finishes before any read responses are processed. More to the point: It also causes us to overflow the maximum number of registered vendor specific UUIDs when performing discovery on some peripherals, like the SensorBug.

Remove the calls to uuidToDriver from_parseGattcReadResponseEvent.