### PR TITLE
Fix for module load issues on Windows with electron 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,35 +21,27 @@ include_directories(${PC_BLE_DRIVER_INCLUDE_DIR}/common/sdk_compat)
 include_directories(${PC_BLE_DRIVER_INCLUDE_DIR}/common/internal)
 include_directories(${PC_BLE_DRIVER_INCLUDE_DIR}/common/internal/transport)
 
-# Specify source files (include win_delay_load_hook.cpp only for Windows)
+file (GLOB SOURCE_FILES
+    "src/adapter.cpp"
+    "src/serialadapter.cpp"
+    "src/common.cpp"
+    "src/driver.cpp"
+    "src/driver_gap.cpp"
+    "src/driver_gatt.cpp"
+    "src/driver_gattc.cpp"
+    "src/driver_gatts.cpp"
+    "src/driver_uecc.cpp"
+    "src/*.h"
+)
+
+# Specify platform specific source files (include win_delay_load_hook.cpp only for Windows)
 if(WIN32)
-    file (GLOB SOURCE_FILES
-        "src/adapter.cpp"
-        "src/serialadapter.cpp"
-        "src/common.cpp"
-        "src/driver.cpp"
-        "src/driver_gap.cpp"
-        "src/driver_gatt.cpp"
-        "src/driver_gattc.cpp"
-        "src/driver_gatts.cpp"
-        "src/driver_uecc.cpp"
+    file (GLOB PLATFORM_SOURCE_FILES1
         "src/win_delay_load_hook.cpp"
-        "src/*.h"
-    )
-else()
-    file (GLOB SOURCE_FILES
-        "src/adapter.cpp"
-        "src/serialadapter.cpp"
-        "src/common.cpp"
-        "src/driver.cpp"
-        "src/driver_gap.cpp"
-        "src/driver_gatt.cpp"
-        "src/driver_gattc.cpp"
-        "src/driver_gatts.cpp"
-        "src/driver_uecc.cpp"
-        "src/*.h"
     )
 endif()
+
+
 
 file (GLOB UECC_SOURCE_FILES
     "src/uECC/*.c"
@@ -81,7 +73,7 @@ foreach(SD_API_VER ${SD_API_VERS})
     string(TOLOWER ${SD_API_VER} SD_API_VER_L)
     set(CURRENT_TARGET pc-ble-driver-js-${SD_API_VER_L})
 
-    add_library(${CURRENT_TARGET} SHARED ${SOURCE_FILES} ${UECC_SOURCE_FILES} ${LIB_PLATFORM_SRC_FILES})
+    add_library(${CURRENT_TARGET} SHARED ${SOURCE_FILES} ${UECC_SOURCE_FILES} ${LIB_PLATFORM_SRC_FILES} ${PLATFORM_SOURCE_FILES})
 
     # This line will give our library file a .node extension without any "lib" prefix
     set_target_properties(${CURRENT_TARGET}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,19 +21,35 @@ include_directories(${PC_BLE_DRIVER_INCLUDE_DIR}/common/sdk_compat)
 include_directories(${PC_BLE_DRIVER_INCLUDE_DIR}/common/internal)
 include_directories(${PC_BLE_DRIVER_INCLUDE_DIR}/common/internal/transport)
 
-# Specify source files
-file (GLOB SOURCE_FILES
-    "src/adapter.cpp"
-    "src/serialadapter.cpp"
-    "src/common.cpp"
-    "src/driver.cpp"
-    "src/driver_gap.cpp"
-    "src/driver_gatt.cpp"
-    "src/driver_gattc.cpp"
-    "src/driver_gatts.cpp"
-    "src/driver_uecc.cpp"
-    "src/*.h"
-)
+# Specify source files (include win_delay_load_hook.cpp only for Windows)
+if(WIN32)
+    file (GLOB SOURCE_FILES
+        "src/adapter.cpp"
+        "src/serialadapter.cpp"
+        "src/common.cpp"
+        "src/driver.cpp"
+        "src/driver_gap.cpp"
+        "src/driver_gatt.cpp"
+        "src/driver_gattc.cpp"
+        "src/driver_gatts.cpp"
+        "src/driver_uecc.cpp"
+        "src/win_delay_load_hook.cpp"
+        "src/*.h"
+    )
+else()
+    file (GLOB SOURCE_FILES
+        "src/adapter.cpp"
+        "src/serialadapter.cpp"
+        "src/common.cpp"
+        "src/driver.cpp"
+        "src/driver_gap.cpp"
+        "src/driver_gatt.cpp"
+        "src/driver_gattc.cpp"
+        "src/driver_gatts.cpp"
+        "src/driver_uecc.cpp"
+        "src/*.h"
+    )
+endif()
 
 file (GLOB UECC_SOURCE_FILES
     "src/uECC/*.c"
@@ -85,6 +101,7 @@ foreach(SD_API_VER ${SD_API_VERS})
 
         target_include_directories(${CURRENT_TARGET} PRIVATE "${CMAKE_JS_INC}/win")
         set_target_properties(${CURRENT_TARGET} PROPERTIES COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
+        set_target_properties(${CURRENT_TARGET} PROPERTIES LINK_FLAGS "/DELAYLOAD:node.exe" )
     elseif(APPLE)
         target_link_libraries(${CURRENT_TARGET} "-framework CoreFoundation")
         target_link_libraries(${CURRENT_TARGET} "-framework IOKit")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ file (GLOB SOURCE_FILES
 
 # Specify platform specific source files (include win_delay_load_hook.cpp only for Windows)
 if(WIN32)
-    file (GLOB PLATFORM_SOURCE_FILES1
+    file (GLOB PLATFORM_SOURCE_FILES
         "src/win_delay_load_hook.cpp"
     )
 endif()

--- a/src/win_delay_load_hook.cpp
+++ b/src/win_delay_load_hook.cpp
@@ -1,0 +1,36 @@
+/*
+ * When this file is linked to a DLL, it sets up a delay-load hook that
+ * intervenes when the DLL is trying to load 'node.exe' or 'iojs.exe'
+ * dynamically. Instead of trying to locate the .exe file it'll just return
+ * a handle to the process image.
+ *
+ * This allows compiled addons to work when node.exe or iojs.exe is renamed.
+ */
+
+#ifdef _MSC_VER
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+
+#include <delayimp.h>
+#include <string.h>
+
+static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+  HMODULE m;
+  if (event != dliNotePreLoadLibrary)
+    return NULL;
+
+  if (_stricmp(info->szDll, "iojs.exe") != 0 &&
+      _stricmp(info->szDll, "node.exe") != 0)
+    return NULL;
+
+  m = GetModuleHandle(NULL);
+  return (FARPROC) m;
+}
+
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
+
+#endif

--- a/src/win_delay_load_hook.cpp
+++ b/src/win_delay_load_hook.cpp
@@ -5,6 +5,8 @@
  * a handle to the process image.
  *
  * This allows compiled addons to work when node.exe or iojs.exe is renamed.
+ *
+ * https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook
  */
 
 #ifdef _MSC_VER


### PR DESCRIPTION
As per electron documentation, module needs to be compiled with delay
load hook otherwise module fails to get loaded

See https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook
After fix, verified that the module works fine with electron 4.0.6 and
4.1.3.