### PR TITLE
Fix compiling on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ foreach(SD_API_VER "2" "3")
         set_property(TARGET ${CURRENT_TARGET} PROPERTY MACOSX_RPATH ON)
     else()
         # Assume Linux
-        target_link_libraries(${CURRENT_TARGET} "udev")
+        target_link_libraries(${CURRENT_TARGET} PRIVATE "udev")
     endif()
 
     target_link_libraries(${CURRENT_TARGET} PRIVATE ${CMAKE_JS_LIB} nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_static)


### PR DESCRIPTION
This PR is due to fixing the following compile issue on Linux
```
info RUN cmake "/home/chfa/dev/workspace/pc-ble-driver-js" --no-warn-unused-cli -G"Ninja" -DCMAKE_JS_VERSION="5.1.0" -DCMAKE_BUILD_TYPE="Release" -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="/home/chfa/dev/workspace/pc-ble-driver-js/build/Release" -DCMAKE_JS_INC="/home/chfa/.cmake-js/node-x64/v8.15.1/include/node;/home/chfa/dev/workspace/pc-ble-driver-js/node_modules/nan" -DNODE_RUNTIME="node" -DNODE_RUNTIMEVERSION="8.15.1" -DNODE_ARCH="x64"
Not searching for unused variables given on the command line.
-- The C compiler identification is GNU 6.3.0
-- The CXX compiler identification is GNU 6.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at CMakeLists.txt:92 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "pc-ble-driver-js-sd_api_v2".  All uses of target_link_libraries
  with a target must be either all-keyword or all-plain.

  The uses of the plain signature are here:

   * CMakeLists.txt:89 (target_link_libraries)



CMake Error at CMakeLists.txt:92 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "pc-ble-driver-js-sd_api_v3".  All uses of target_link_libraries
  with a target must be either all-keyword or all-plain.

  The uses of the plain signature are here:

   * CMakeLists.txt:89 (target_link_libraries)



-- Configuring incomplete, errors occurred!
See also "/home/chfa/dev/workspace/pc-ble-driver-js/build/CMakeFiles/CMakeOutput.log".
```