### PR TITLE
Correct reference to project core/launcher

### DIFF
--- a/build.js
+++ b/build.js
@@ -35,7 +35,7 @@
  */
 
 // Wrapper script for cmake-js. Translates and forwards npm config options
-// understood by node-gyp. This script is needed because pc-nrfconnect-core
+// understood by node-gyp. This script is needed because pc-nrfconnect-launcher
 // supplies config for only node-gyp.
 require('child_process').execFileSync(process.platform === 'win32' ? 'npx.cmd' : 'npx', [
     'cmake-js',


### PR DESCRIPTION
This is part of [NCP-2704](https://projecttools.nordicsemi.no/jira/browse/NCP-2704).

The project `pc-nrfconnect-core` was renamed to `pc-nrfconnect-launcher`. This corrects references to the old name (links are redirected but it might still be confusing to keep on using the old name).