### PR TITLE
Upgrade nrf-device-lister dependency

### DIFF
--- a/api/adapterFactory.js
+++ b/api/adapterFactory.js
@@ -161,8 +161,8 @@ class AdapterFactory extends EventEmitter {
 
         if (adapter.serialNumber) {
             instanceId = adapter.serialNumber;
-        } else if (adapter.comName) {
-            instanceId = adapter.comName;
+        } else if (adapter.path) {
+            instanceId = adapter.path;
         } else {
             this.emit('error', 'Failed to get adapter\'s instanceId.');
         }
@@ -219,7 +219,7 @@ class AdapterFactory extends EventEmitter {
             notSupportedMessage = 'Note: Adapters with Segger JLink debug probe requires MSD to be disabled to function properly on OSX. Please visit www.nordicsemi.com/nRFConnectOSXfix for further instructions.';
         }
 
-        return new Adapter(selectedDriver, addOnAdapter, instanceId, adapter.comName, adapter.serialNumber, notSupportedMessage);
+        return new Adapter(selectedDriver, addOnAdapter, instanceId, adapter.path, adapter.serialNumber, notSupportedMessage);
     }
 
     _setUpListenersForAdapterOpenAndClose(adapter) {
@@ -309,16 +309,16 @@ class AdapterFactory extends EventEmitter {
      * Create Adapter with custom serialport
      *
      * @param sdVersion {string} Softdevice API version: 'v2' or 'v5'.
-     * @param comName {string} Serialport name (eg. 'COM7' on windows).
+     * @param path {string} Serialport name (eg. 'COM7' on windows).
      * @param instanceId {string} The unique Id that identifies this Adapter instance.
      * @returns {Adapter} Created adapter.
      */
-    createAdapter(sdVersion, comName, instanceId) {
+    createAdapter(sdVersion, path, instanceId) {
         if (sdVersion !== 'v2' && sdVersion !== 'v5') {
             throw new Error('Unsupported soft-device version!');
         }
-        if (typeof comName === 'undefined') {
-            throw new Error('Missing parameter: comName!');
+        if (typeof path === 'undefined') {
+            throw new Error('Missing parameter: path!');
         }
         if (typeof instanceId === 'undefined') {
             throw new Error('Missing parameter: instanceId!');
@@ -327,7 +327,7 @@ class AdapterFactory extends EventEmitter {
         const selectedDriver = this._bleDrivers[sdVersion];
         const addOnAdapter = new selectedDriver.Adapter();
 
-        return new Adapter(selectedDriver, addOnAdapter, instanceId, comName);
+        return new Adapter(selectedDriver, addOnAdapter, instanceId, path);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "jshint": "^2.10.2",
     "minami": "^1.2.3",
     "node-pre-gyp-github": "1.4.3",
-    "nrf-device-setup": "^0.6.2"
+    "nrf-device-setup": "^0.6.5"
   },
   "files": [
     "api/",

--- a/src/serialadapter.cpp
+++ b/src/serialadapter.cpp
@@ -79,7 +79,7 @@ void AfterGetAdapterList(uv_work_t* req)
         for(auto adapterItem : baton->results)
         {
             v8::Local<v8::Object> item = Nan::New<v8::Object>();
-            Utility::Set(item, "comName", adapterItem.port);
+            Utility::Set(item, "path", adapterItem.port);
             Utility::Set(item, "manufacturer", adapterItem.manufacturer);
             Utility::Set(item, "serialNumber", adapterItem.serialNumber);
             Utility::Set(item, "pnpId", adapterItem.pnpId);

--- a/src/serialadapter_linux.cpp
+++ b/src/serialadapter_linux.cpp
@@ -134,7 +134,7 @@ void GetAdapterList(uv_work_t* req)
         {
             AdapterListResultItem* resultItem = new AdapterListResultItem();
 
-            resultItem->comName = device->port;
+            resultItem->path = device->port;
 
             if (device->locationId != NULL)
             {

--- a/src/serialadapter_osx.cpp
+++ b/src/serialadapter_osx.cpp
@@ -373,7 +373,7 @@ void GetAdapterList(uv_work_t* req) {
         {
             AdapterListResultItem* resultItem = new AdapterListResultItem();
 
-            resultItem->comName = device->port;
+            resultItem->path = device->port;
 
             if (device->locationId != NULL)
             {

--- a/test/setup.js
+++ b/test/setup.js
@@ -271,7 +271,7 @@ async function _grabAdapter(serialNumber, options) {
 
     return {
         serialNumber: selectedAdapter.serialNumber,
-        port: selectedAdapter.serialport.comName,
+        port: selectedAdapter.serialport.path,
         apiVersion: softDeviceParams.sdVersion,
         baudRate: softDeviceParams.baudRate,
     };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -272,7 +272,7 @@ declare class Adapter extends EventEmitter {
 export declare class AdapterFactory extends EventEmitter {
   static getInstance(): AdapterFactory;
   getAdapters(callback?: (err: any, adapters: Adapter[]) => void): void;
-  createAdapter(sdVersion: 'v2' | 'v3', comName: string, instanceId: string): Adapter;
+  createAdapter(sdVersion: 'v2' | 'v3', path: string, instanceId: string): Adapter;
 }
 
 export declare class ServiceFactory {


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

This brings along the upgraded serialport dependency, which renames the property `comName` to `path`.

From my limited understanding of the `pc-ble-driver-js` project, this project partially contains copies of the `serialport` code, so we might not have update the property here, but still it seems to me, that it would be good to stay in sync.

Is this correct? 

Also: I did not understand, whether this project does expose the `comName` to other code using this project. Do we have to duck tape the old property, so that we do not break other code?