### PR TITLE
Update version strings

### DIFF
--- a/api/firmwareRegistry.js
+++ b/api/firmwareRegistry.js
@@ -46,8 +46,8 @@ const hexDir = path.join(currentDir, '..', '..', 'build', 'Release', 'pc-ble-dri
 const VERSION_INFO_MAGIC = 0x46D8A517;
 const VERSION_INFO_LENGTH = 24;
 
-const connectivityVersion = '4.1.2';
-const connectivityApplicationVersionString = 'ble-connectivity 4.1.2+Jul-14-2020-05-48-48';
+const connectivityVersion = '4.1.4';
+const connectivityApplicationVersionString = 'ble-connectivity 4.1.4+Mar-11-2021-08-36-04';
 const connectivityBaudRate = 1000000;
 
 /*


### PR DESCRIPTION
Versions strings were outdated, causing the BLE-app to crash on opening.