### PR TITLE
Fix incorrect parsing of Out-Of-Band data

### DIFF
--- a/api/adapter.js
+++ b/api/adapter.js
@@ -2977,13 +2977,18 @@ class Adapter extends EventEmitter {
             return;
         }
 
-        // If the key is a string we split it into a byte array before we call gapReplyAuthKey
+        // If the key is a string we split it into an array before we call gapReplyAuthKey
         if (key && key.constructor === String) {
-            const bytes = [];
-            for (var c = 0; c < key.length; c += 2) {
-                bytes.push(parseInt(key.substr(c, 2), 16));
+            if (keyType === this.driver.BLE_GAP_AUTH_KEY_TYPE_OOB) {
+                // OOB key is a hex string which must be converted appropriate
+                const bytes = [];
+                for (var c = 0; c < key.length; c += 2) {
+                    bytes.push(parseInt(key.substr(c, 2), 16));
+                }
+                key = bytes;
+            } else {
+                key = Array.from(key);
             }
-            key = bytes;
         }
 
         this._adapter.gapReplyAuthKey(device.connectionHandle, keyType, key, err => {

--- a/api/adapter.js
+++ b/api/adapter.js
@@ -2977,9 +2977,13 @@ class Adapter extends EventEmitter {
             return;
         }
 
-        // If the key is a string we split it into an array before we call gapReplyAuthKey
+        // If the key is a string we split it into a byte array before we call gapReplyAuthKey
         if (key && key.constructor === String) {
-            key = Array.from(key);
+            const bytes = [];
+            for (var c = 0; c < key.length; c += 2) {
+                bytes.push(parseInt(key.substr(c, 2), 16));
+            }
+            key = bytes;
         }
 
         this._adapter.gapReplyAuthKey(device.connectionHandle, keyType, key, err => {


### PR DESCRIPTION
Inputting Out-Of-Band data will never be possible, as the input is not parsed as hex string put every char in the hex string will be converted to its ascii representation thus also only considering the first 8 bytes.

There are some reports considering this issue:
https://devzone.nordicsemi.com/f/nordic-q-a/47932/oob-works-with-mcp-but-fails-with-nrf-connect
https://devzone.nordicsemi.com/f/nordic-q-a/16693/error-oob-static-key-nrf-connect

This pull request will fix this by converting every hex byte in the hex string as byte.

![182859693-9552eb1c-09a9-4e22-9898-8e8a4a747bab](https://user-images.githubusercontent.com/24536170/182872383-b16552b3-29d7-40d5-9d7f-b09257c781a7.png)